### PR TITLE
feat: publish rereadme as composite GitHub Action (v0.0.1)

### DIFF
--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -2,8 +2,7 @@ name: README CI Suggestions
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   readme-suggestions:
@@ -14,43 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-node@v4
+      - uses: connorludwig/rereadme@v0.0.1
         with:
-          node-version: "24"
-
-      - run: npm ci
-
-      - name: Analyze diff and generate README suggestions
-        run: npm run dev -- --ci --verbose --base-ref origin/main --head-ref HEAD
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
-      - name: Post suggestions as PR comment
-        if: hashFiles('README-suggestions.md') != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const marker = '<!-- readme-agent -->'
-            const fs = require('fs')
-            const body = `${marker}\n${fs.readFileSync('README-suggestions.md', 'utf8').trim()}`
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number: context.issue.number,
-            })
-            const existing = comments.find(c => c.body && c.body.includes(marker))
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body,
-              })
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body,
-              })
-            }
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: connorludwig/rereadme@v0.0.1
+      - uses: cjlludwig/ReReadme@v0.0.1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.1
+      - uses: cjlludwig/ReReadme@v0.0.2
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+name: rereadme
+description: Analyze PR diffs and suggest README updates
+inputs:
+  openai-api-key:
+    required: true
+    description: key
+  base-ref:
+    default: origin/main
+    description: Base branch to compare against. Defaults to origin/main. Variants may be origin/master, origin/prod, etc.
+  verbose:
+    default: "false"
+    description: Enable verbose agent trace output for debugging.
+  model:
+    description: Override the default model (e.g. gpt-4o). Omit to use the built-in default.
+branding:
+  icon: file-text
+  color: blue
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "24"
+    - run: npm ci
+      shell: bash
+      working-directory: ${{ github.action_path }}
+    - run: node ${{ github.action_path }}/bin/rereadme.js --ci --base-ref ${{ inputs.base-ref }} --head-ref HEAD ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+      shell: bash
+      env:
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+    - if: hashFiles('README-suggestions.md') != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const marker = '<!-- rereadme-agent -->'
+          const fs = require('fs')
+          const body = `${marker}\n${fs.readFileSync('README-suggestions.md', 'utf8').trim()}`
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            ...context.repo, issue_number: context.issue.number
+          })
+          const existing = comments.find(c => c.body?.includes(marker))
+          if (existing) {
+            await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body })
+          } else {
+            await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body })
+          }

--- a/bin/rereadme.js
+++ b/bin/rereadme.js
@@ -12,7 +12,8 @@ const __dirname = dirname(__filename);
 const scriptPath = join(__dirname, '..', 'script.ts');
 
 // Use tsx to execute the TypeScript script with all command line arguments
-const child = spawn('npx', ['tsx', scriptPath, ...process.argv.slice(2)], {
+const tsxBin = join(__dirname, '..', 'node_modules', '.bin', 'tsx');
+const child = spawn(tsxBin, [scriptPath, ...process.argv.slice(2)], {
   stdio: 'inherit',
   cwd: process.cwd()
 });


### PR DESCRIPTION
## Summary

Packages rereadme as a published composite GitHub Action so any repo can consume it with a single `uses: connorludwig/rereadme@v0.0.1` line, eliminating the need to copy inline workflow steps. Adds `action.yml` at the repo root, fixes `bin/rereadme.js` to use the action's own installed `tsx` binary, and collapses the inline CI workflow to a single `uses:` call.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Changes made

- `action.yml` — new composite action definition with `openai-api-key` (required), `base-ref` (default: `origin/main`), `verbose` (default: `false`), and `model` (optional, falls back to built-in default) inputs
- `bin/rereadme.js` — changed `spawn('npx', ['tsx', ...])` to use `node_modules/.bin/tsx` resolved relative to `__dirname`, so the action uses its own installed binary rather than the caller's environment
- `.github/workflows/readme-ci.yml` — replaced all inline steps with a single `uses: connorludwig/rereadme@v0.0.1` call

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)