### PR TITLE
docs: add developer and usage documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 > [!WARNING]
 > If you're not comfortable or allowed to leverage Dev AI tools on your codebase this may not be the right tool for you.
-> This tool allows OpenAI Agents to inspect relevant files within a repo to determine repo details.
-> Check compliance policies before usage.
+> This tool allows OpenAI Agents to inspect Git tracked files within a repo to determine repo details.
+>
+> See [Security](docs/security.md) for access protections and [Observability](docs/observability.md) for agent trace visibility.
 
 The rereadme CLI tool automatically refreshes README.md files by analyzing the repository and processing findings with AI. It uses a multi-agent architecture (Researcher → DetailFetcher → TemplateEnforcer) powered by the OpenAI Agents SDK to explore a codebase, distill the discovered context into a polished README, and apply a consistent structure.
 
@@ -58,6 +59,8 @@ npm run check
 ```
 
 ## Usage
+
+> For real-world usage scenarios, see [Workflows](docs/workflows.md).
 
 ### CLI Tool Usage (Global Installation)
 
@@ -119,6 +122,8 @@ npm run help                       # Show help
 
 ### Custom Templates
 
+> For template design guidance and conventions, see [Templates](docs/templates.md).
+
 You can supply your own markdown template with `--template FILE` (for README) or `--agents-template FILE` (for AGENTS.md, requires `--agents`).
 
 Template requirements:
@@ -166,11 +171,19 @@ Additional implementation details:
 
 ## Architecture
 
+> For local setup, development workflow, and contribution standards, see [Development](docs/development.md).
+
 The tool is built using:
 
 - **Google ZX** - Node.js CLI script framework for shell operations
 - **OpenAI Agents SDK** - AI processing of documentation content
 - **TypeScript** - Type-safe development with modern JavaScript features
+
+## Quality
+
+LLMs are inherently non-deterministic, so rereadme takes a two-layer approach to agent quality. Tool calls are tested explicitly in the Jest unit suite to assert allowed filesystem actions and path boundaries — the deterministic, security-critical behavior that must hold on every run. General output quality — structure, accuracy, completeness — is validated through a DeepEval eval framework that runs rereadme against real dataset repos and compares output against golden READMEs using both deterministic checks and an LLM-as-judge metric.
+
+See [evals/README.md](evals/README.md) for setup, metrics, and the golden README workflow.
 
 ## Help
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,98 @@
+# Development
+
+How to set up the repo locally, run the tool in development, execute tests and evals, and keep quality checks passing.
+
+## Prerequisites
+
+- **Node.js >= 22** — enforced by `engines.node` in `package.json`
+- **uv** — Python package manager for the eval framework ([install](https://docs.astral.sh/uv/)); requires Python >= 3.11
+- **OPENAI_API_KEY** — set in your environment before running the tool or evals
+
+## Setup
+
+```shell
+git clone https://github.com/connorludwig/rereadme.git
+cd rereadme
+npm install        # installs deps + configures the husky pre-commit hook automatically
+```
+
+To also set up the eval framework and dataset submodules:
+
+```shell
+npm run setup
+# Equivalent to:
+# git submodule update --init evals/datasets/express-server evals/datasets/rereadme
+# cd evals && uv sync
+```
+
+The two eval dataset submodules are:
+
+- `evals/datasets/express-server` — Node.js/Express/MongoDB sample project
+- `evals/datasets/rereadme` — rereadme's own repo (used for self-referencing eval)
+
+## Development Workflow
+
+```shell
+npm run dev                        # run the tool via tsx (no compile step)
+npm run dev -- --verbose           # with agent trace output
+npm run dev -- --interactive       # pause between steps for review
+npm run dev -- --check             # dependency check only
+npm run dev -- --model gpt-4o      # override the default model
+npm run build                      # compile TypeScript to dist/
+```
+
+To install globally from source and use the `rereadme` CLI directly:
+
+```shell
+npm link
+rereadme --help
+```
+
+## Tests
+
+Unit tests cover tool calls, agent definitions, and the runner:
+
+```shell
+npm test                           # run Jest suite with coverage
+```
+
+Eval framework runs rereadme against real dataset repos and compares output against golden READMEs:
+
+```shell
+npm run eval                       # all experiments
+npm run eval:rereadme              # rereadme self-referencing experiment only
+npm run eval:agents                # agents doc experiments
+npm run eval:ci                    # CI mode tests
+npm run eval:all                   # full pytest suite
+npm run eval:report                # evaluation report
+```
+
+See [evals/README.md](../evals/README.md) for metrics, golden README workflow, and CI plans.
+
+## Quality Gate
+
+`make check` runs all static analysis — ESLint, markdownlint, ruff, tsc, mypy, depcheck, deptry:
+
+```shell
+make check                         # full quality gate (fail-fast)
+make fix                           # auto-fix: eslint --fix, markdownlint --fix, ruff --fix
+make test                          # Jest only
+make lint-ts                       # ESLint only
+make lint-md                       # markdownlint only
+make typecheck-ts                  # tsc --noEmit only
+```
+
+The **pre-commit hook** (installed automatically by `npm install` via husky) runs on every commit:
+
+1. `lint-staged` — auto-fixes staged `.ts`/`.js` files with ESLint and `.md` files with markdownlint
+2. `make pre-commit` — type-checks, Python lint, and dependency audits
+3. `make test` — full Jest suite
+
+A **PostToolUse hook** in `.claude/settings.json` runs `make check` after every file write or edit when working with Claude Code.
+
+## Standards
+
+- **TypeScript** — typescript-eslint recommended + type-checked rules; no implicit `any`
+- **Markdown** — markdownlint enforced; auto-fixable issues resolved by `make fix`
+- **Python** — ruff for linting, mypy for type-checking (eval framework only)
+- **Tests must pass before commit** — the pre-commit hook enforces this; do not use `--no-verify`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,57 @@
+# Observability
+
+Because rereadme runs on your OpenAI API key, all inference, traces, and usage data live in your account — no telemetry is routed anywhere else. The OpenAI Agents SDK instruments every run automatically: tool calls, agent handoffs, model inferences, and timing are all captured without any configuration in the codebase.
+
+## What Gets Traced
+
+Each rereadme run produces one trace per workflow. The agents you will see by name:
+
+**Standard workflow (`rereadme`):**
+
+- `Researcher` — repo exploration and context gathering
+- `DetailFetcher` — targeted follow-up queries (when Researcher hands off for a missing fact)
+- `TemplateEnforcer` — README generation from accumulated context
+- `AgentsDocWriter` — agents doc generation (only when `--agents` is passed)
+
+**CI workflow (`rereadme --ci`):**
+
+- `DiffAnalyzer` — diff significance evaluation
+- `ReadmePatcher` — surgical README suggestion generation (only when diff is significant)
+
+These names come from the `name` field on each `Agent` definition in `lib/agents.ts`.
+
+## View Traces
+
+Traces land in your OpenAI account in real time as each run completes.
+
+1. Go to [platform.openai.com/logs](https://platform.openai.com/logs?api=traces) and select the **Traces** tab
+2. Each rereadme run appears as a top-level trace entry
+3. Expand a trace to see individual agent spans, tool calls, and handoffs with latency and token counts
+
+For setup steps and filtering options, see the [OpenAI tracing guide](https://openai.github.io/openai-agents-js/guides/tracing/).
+
+## Use Traces for Debugging
+
+Traces are most useful when a run produces unexpected output:
+
+- **Agent skipped a section** — check the `Researcher` span; look at which files were read and whether the relevant file was accessed
+- **Handoff happened unexpectedly** — inspect the `TemplateEnforcer` span to see what triggered the handoff to `DetailFetcher`
+- **CI mode did not flag a change** — check the `DiffAnalyzer` span and its structured output for `signalLevel` and `significanceReason`
+- **Run was slow** — span latencies show where time was spent (typically the largest model inference call)
+
+## Live Output in the Terminal
+
+Pass `--verbose` to stream agent trace output to the terminal during a run:
+
+```shell
+rereadme --verbose
+rereadme --ci --verbose
+```
+
+This shows tool calls and agent transitions in real time — useful for local development and debugging without opening the platform UI.
+
+## References
+
+- [OpenAI Agents SDK — Tracing guide](https://openai.github.io/openai-agents-js/guides/tracing/)
+- [OpenAI Platform — Traces](https://platform.openai.com/logs?api=traces)
+- [rereadme README](../README.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,33 @@
+# Security
+
+Key security properties for teams evaluating rereadme for use in shared environments or CI pipelines.
+
+## Filesystem Access Is Sandboxed to the Repo Root
+
+Every path the agent requests is resolved against the working directory and rejected if it escapes it (`safePath()` in `lib/tools.ts`). No file outside the repo root can be accessed, regardless of what the agent requests.
+
+## Gitignored Files Are Never Exposed to the Agent
+
+All four filesystem tools enforce gitignore rules before returning content:
+
+- `read_file` and `get_structure` check gitignore status and throw `Access denied` if a file is ignored
+- `search_code` uses globby with `gitignore: true`, so ignored files are excluded before any content is read
+- `list_directory` filters the result set through gitignore before returning entries
+
+Secrets, credentials, and other sensitive files that belong in `.gitignore` are not sent to the AI.
+
+## The Tool Only Operates in Git Repositories
+
+Gitignore enforcement requires git. The tool does not run outside a git repo, which ensures the above protections are always active.
+
+## The API Key Is Never Logged or Written to Disk
+
+`OPENAI_API_KEY` is read from the environment and passed to the OpenAI client. It is not included in any output files, agent traces, or verbose logs.
+
+## Agents Have No Write Access
+
+The agent tools (`list_directory`, `read_file`, `search_code`, `get_structure`) are read-only. File writes happen only at the CLI layer: the generated README and a timestamped backup (`script.ts`). In CI mode, the README is never modified unless `--apply` is explicitly passed.
+
+## Outbound Network Calls Are Limited to the OpenAI API
+
+The only external network calls are to the OpenAI API via the Agents SDK. No telemetry or other services are contacted.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,54 @@
+# Templates
+
+A template is the contract between you and the agent. It defines what sections exist, what each section must contain, and what the final output looks like. Clear guidance produces accurate READMEs; vague or over-structured templates produce filler. The built-in templates are designed around this principle — see [Using Markdown Templates with AI](https://cjlludwig.github.io/blog/using-markdown-templates-with-ai) for the full design rationale.
+
+## How rereadme Uses Templates
+
+Each template uses two mechanisms to communicate with the agent:
+
+**HTML comment blocks** (`<!-- -->`) contain hard rules for the agent — required headings, output format constraints, what to omit. These are LLM instructions and do not appear in the final output.
+
+**Blockquote lines** (`>`) contain section-specific content guidance — what facts to extract and how to format them. The agent replaces each blockquote with discovered content and removes it from the final output.
+
+Everything else — headings, code block labels, example shapes, badge placeholders — is literal structure the agent preserves verbatim. The agent fills the gaps; it does not invent the skeleton.
+
+## Built-in Templates
+
+Two templates ship with rereadme:
+
+- `templates/README_TEMPLATE.md` — standard README covering Description, Getting Started, Usage, Architecture, References, Help, and License
+- `templates/AGENTS_TEMPLATE.md` — concise AGENTS.md covering Project, Commands, Structure, Architecture, Constraints, and Testing (target: < 100 lines)
+
+Both follow the conventions below and are the best reference for writing your own.
+
+## Custom Templates
+
+Pass `--template FILE` to use your own README template, or `--agents-template FILE` for a custom AGENTS.md (requires `--agents`):
+
+```shell
+rereadme --template COMPANY_README_TEMPLATE.md
+rereadme --agents --agents-template COMPANY_AGENTS_TEMPLATE.md
+```
+
+Requirements for a valid custom template:
+
+- Valid markdown with at least one heading (`#`)
+- Use `>` blockquote lines as content placeholders — the agent targets these for replacement
+- Maximum size: 50KB
+
+## Template Conventions
+
+These conventions are drawn from the built-in templates and the design guidance in the blog post:
+
+**Lead with a rules comment.** Place a `<!-- TEMPLATE RULES -->` block at the top listing what headings are required, what the agent must and must not do, and the expected output format. This sets hard constraints before the agent reads anything else.
+
+**Comments for LLM rules, blockquotes for content guidance.** Use `<!-- -->` for instructions the agent should follow but that shouldn't appear in output. Use `>` blockquotes for section-level guidance the agent replaces with real content.
+
+**Mark optional sections explicitly.** Add `(Optional)` to any section the agent should omit when no relevant data was found. Without this, agents generate filler text to satisfy structure.
+
+**Keep sections shallow.** Aim for five or six sections maximum and no more than three levels of heading depth. Excessive structure creates busywork — sections that don't apply get filler written purely to satisfy the template.
+
+## References
+
+- [Using Markdown Templates with AI](https://cjlludwig.github.io/blog/using-markdown-templates-with-ai)
+- [rereadme README](../README.md)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,110 @@
+# Workflows
+
+In an AI-assisted workflow, every agent session without context pays to rediscover it — reading files, inferring structure, guessing conventions. A well-maintained README amortizes that cost: pay once to persist context, not repeatedly to rediscover it. These workflows show how rereadme fits into local development and CI pipelines to keep that context current.
+
+## Generate a README from Scratch
+
+No README? Run rereadme to generate one — the tool explores your repo structure and distills it into a polished doc.
+
+```shell
+# Before
+ls README.md
+# ❌ ls: README.md: No such file or directory
+```
+
+```shell
+# After
+rereadme --verbose
+ls README.md
+# ✨ README.md
+```
+
+## Refresh an Outdated README
+
+Placeholder or stub READMEs are common — run rereadme to replace boilerplate with accurate, repo-specific content.
+
+```shell
+# Before
+cat README.md
+# # My Repo
+#
+#  TODO
+```
+
+```shell
+# After
+rereadme
+cat README.md
+# # My Repo
+#
+#  A service aimed at...
+#
+# ## Usage...
+```
+
+## Enforce a Consistent Format Across Repos
+
+Repos accumulate inconsistent structures over time — use `--template` with a shared company template to normalize them in one pass.
+
+```shell
+# Before: each repo has its own ad-hoc structure
+cat README.md   # → ## Setup
+cat README2.md  # → ## Usage
+cat README3.md  # → ## Description
+```
+
+```shell
+# After: run rereadme in each repo with a shared template
+rereadme --template COMPANY_README_TEMPLATE.md
+cat README.md
+# # My Repo
+#
+# ## Description
+# ...
+# ## Setup
+# ...
+# ## Usage
+# ...
+```
+
+## Catch Documentation Drift in CI
+
+Add the published GitHub Action to your PR pipeline — on every pull request, it reads the diff, detects whether changes warrant a README update, and posts suggestions as a PR comment without modifying the README.
+
+```yaml
+# .github/workflows/readme-ci.yml
+name: README CI Suggestions
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  readme-suggestions:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cjlludwig/ReReadme@v0.0.2
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+# ⚠️ README-suggestions.md written on drift
+# ✍️ PR comment posted automatically
+```
+
+## Auto-Apply Doc Updates in CI
+
+Add `--apply` to go further: patches are written directly to `README.md` so docs stay in sync without manual review.
+
+```shell
+git --no-pager diff
+# diff --git a/blogs/2-22-26-rereadme.md b/blogs/2-22-26-rereadme.md
+# -title: "ReReadme: Doc made simple"
+# +title: "ReReadme: Doc-as-ci"
+# ... (remaining diff omitted)
+
+rereadme --ci --apply
+
+# ♻️ README.md
+```


### PR DESCRIPTION
## Summary

Adds a full documentation suite covering workflows, security, observability, templates, and development setup. Each doc is written with a specific audience in mind, grounded in the actual codebase, and cross-linked from the README at intuitive entry points. Also adds a plan for the terminal GIF demo and wires in a pre-check enforcing git repo presence before any workflow runs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `docs/workflows.md` — rewrote with framing intro, benefit-oriented headers, before/after code blocks, collapsed CI diffs, and GHA usage for the "Catch Documentation Drift in CI" scenario
- `docs/security.md` — expanded from 2 bullets to 6 sections covering filesystem sandboxing, gitignore enforcement, git-only requirement, API key handling, write scope, and network access; grounded in `lib/tools.ts`
- `docs/observability.md` — replaced stub with full doc: what gets traced per workflow, how to view traces in the OpenAI platform, debugging scenarios tied to named agents, and `--verbose` live output
- `docs/templates.md` — replaced one-liner with explanation of comment/blockquote mechanics, built-in template reference, custom template requirements, and conventions from the design blog post
- `docs/development.md` — filled out from stub: prerequisites, setup (including submodule init), dev workflow, test and eval commands, quality gate targets, pre-commit hook details, and standards
- `docs/plans/plan-gif-demo.md` — new plan for asciinema + agg terminal demo GIF with toolchain, recording steps, agg flags, README embed placement, and optional vhs tape
- `README.md` — added cross-links to each doc at intuitive entry points (security/observability near the WARNING callout, workflows in Usage, templates in Custom Templates, development in Architecture, evals in Quality); added `## Quality` section on the two-layer testing philosophy
- `script.ts` — added `checkGitRepo()` helper using `git rev-parse --git-dir`; wired into `checkDependencies()` and `checkCiDependencies()` so `--check` covers it and all workflows enforce git repo presence

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`make check` passes on all modified files. `make lint-md` passes across all docs.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)