### PR TITLE
perf: add batch tools to cut Researcher tool calls from 19 to 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,12 @@ dist
 script.js
 README-suggestions.md
 
+**/.DS_Store
+
+# Demo assets
+evals/datasets/front-end/README.md.original
+local/
+
 # Experiments + Evals
 evals/__pycache__/
 evals/.pytest_cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "evals/datasets/rereadme"]
 	path = evals/datasets/rereadme
 	url = https://github.com/cjlludwig/readme-refresh
+[submodule "evals/datasets/front-end"]
+	path = evals/datasets/front-end
+	url = https://github.com/microservices-demo/front-end

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: lint-ts lint-md lint-py typecheck-ts typecheck-py deps-ts deps-py test check fix
 
+-include local/Makefile
+
 lint-ts:
 	@echo "==> ESLint"
 	npx eslint
@@ -46,3 +48,4 @@ fix:
 	@echo "==> ruff --fix"
 	cd evals && uv run ruff check --fix . || true
 	@echo "==> Fixes applied"
+

--- a/docs/plans/plan-batch-tools-reduce-tool-calls.md
+++ b/docs/plans/plan-batch-tools-reduce-tool-calls.md
@@ -1,0 +1,198 @@
+# Plan: Batch Tools to Reduce Researcher Tool Call Count
+
+## Context
+
+The Researcher agent currently makes ~19 tool calls per run against the express-server dataset (measured 2026-03-03):
+
+```json
+{
+  "toolCallCount": 19,
+  "toolCallsByAgent": { "Researcher": 19 },
+  "toolCallsByTool": { "list_directory": 6, "read_file": 13 }
+}
+```
+
+All 19 calls originate from the Researcher — 6 `list_directory` traversals + 13 individual `read_file` calls. Each tool call re-sends the full growing conversation history, so call count compounds cost nonlinearly and hits the OpenAI 200k TPM/min limit on more complex repos.
+
+This plan adds two new batch tools and tightens researcher instructions to cut calls from ~19 to ≤ 15 (the budget set in `plan-tool-call-stats-eval-metric.md`).
+
+---
+
+## Approach
+
+Three levers:
+
+1. **`get_file_tree` tool** — replaces all `list_directory` traversals with one globby call returning the full repo file list
+2. **`read_files` tool** — replaces individual `read_file` calls with batched multi-file reads
+3. **Researcher instruction updates** — guide the agent to prefer the new tools and skip low-signal files (tests, docs)
+
+---
+
+## File 1: `lib/tools.ts`
+
+### 1a. Add `get_file_tree` tool (after `getStructure`, before `allTools`)
+
+Returns all repo files matching glob patterns in one call. Replaces the `list_directory` → explore subdir → `list_directory` recursion pattern.
+
+```typescript
+export const getFileTree = tool({
+  name: 'get_file_tree',
+  description:
+    'Get a flat list of all repo files matching glob patterns. Faster than repeated list_directory calls. ' +
+    'Use exclude patterns (prefix with !) to filter noise, e.g. ["**/*", "!**/*.spec.ts", "!tests/**"]. ' +
+    'Returns one relative path per line.',
+  parameters: z.object({
+    patterns: z
+      .array(z.string())
+      .default(['**/*'])
+      .describe('Globby include/exclude patterns. Prefix with ! to exclude.'),
+  }),
+  execute: async (input) => {
+    const files = await globby(input.patterns, {
+      cwd: ROOT,
+      gitignore: true,
+      dot: true,
+      ignore: ['.git/**', 'node_modules/**'],
+    });
+    return files.length > 0 ? files.join('\n') : 'No files matched.';
+  },
+});
+```
+
+### 1b. Add `read_files` tool (after `getFileTree`, before `allTools`)
+
+Reads up to 8 files in one tool call. Each call re-sends conversation history, so batching 5 reads into 1 call saves ~4× the per-call token overhead.
+
+```typescript
+export const readFiles = tool({
+  name: 'read_files',
+  description:
+    'Read multiple files at once. Prefer this over repeated read_file calls when you know which files you need. ' +
+    'Returns each file\'s content labeled with its path. Max 8 files per call.',
+  parameters: z.object({
+    paths: z
+      .array(z.string())
+      .max(8)
+      .describe('Relative paths from repo root'),
+    maxLinesEach: z
+      .number()
+      .default(300)
+      .max(500)
+      .describe('Max lines to return per file'),
+  }),
+  execute: async (input) => {
+    const isIgnored = await isGitIgnored({ cwd: ROOT });
+    const results: string[] = [];
+    for (const p of input.paths) {
+      const filePath = safePath(p);
+      if (isIgnored(path.relative(ROOT, filePath))) {
+        results.push(`### ${p}\n[Access denied: gitignored]`);
+        continue;
+      }
+      try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n').slice(0, input.maxLinesEach);
+        const truncated = lines.length < content.split('\n').length;
+        const header = `### ${p}`;
+        const body = lines.join('\n');
+        const footer = truncated
+          ? `\n[... truncated at ${input.maxLinesEach} lines]`
+          : '';
+        results.push(`${header}\n${body}${footer}`);
+      } catch {
+        results.push(`### ${p}\n[Error: file not found or unreadable]`);
+      }
+    }
+    return results.join('\n\n---\n\n');
+  },
+});
+```
+
+### 1c. Update `allTools` export to include both new tools
+
+```typescript
+export const allTools = [listDirectory, readFile, searchCode, getStructure, getFileTree, readFiles];
+```
+
+Keep `listDirectory` and `readFile` in `allTools` — they remain available for targeted single-file reads and backward compatibility with `DetailFetcher`.
+
+---
+
+## File 2: `lib/agents.ts`
+
+### 2a. Import new tools
+
+```typescript
+import { listDirectory, readFile, searchCode, getStructure, getFileTree, readFiles, diffTools } from './tools.js';
+```
+
+### 2b. Update `Researcher` tools list
+
+```typescript
+tools: [getFileTree, readFiles, listDirectory, readFile, searchCode, getStructure],
+```
+
+`getFileTree` and `readFiles` listed first so the model sees them as preferred. `listDirectory` and `readFile` kept for single-file follow-ups when needed.
+
+### 2c. Update Researcher instructions — add Phase 1 guidance to use `get_file_tree`, Phase 2 to batch reads, and skip test files
+
+Replace the current Phase 1/2 description with:
+
+```
+**Phase 1 — Map the repo structure**
+Call get_file_tree once with ["**/*"] to get the full file list. You now have the complete repo map — do NOT make further list_directory calls.
+
+From the file list, identify key files to read:
+- Manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, etc.)
+- Entry points and main source files
+- Configuration files (tsconfig, Dockerfile, docker-compose, CI/CD, .devcontainer/)
+- Documentation files (README, docs/)
+
+Skip test files (*.spec.ts, *.test.ts, tests/, __tests__/), lock files, and generated output — they don't contribute README content.
+
+**Phase 2 — Read key files in batches**
+Use read_files to read 4–6 related files per call (e.g., manifest + entry points together, then config files together). Use read_file only for single follow-up lookups. Use get_structure instead of read_files for large source files when you only need exported signatures.
+
+Target ≤ 4 read_files calls total. Stop reading once you have enough to populate every template section — do not read files for completeness alone.
+```
+
+---
+
+## File 3: `lib/tools.ts` test coverage
+
+### 3a. Add tests for `getFileTree` and `readFiles` in `tests/tools.spec.ts`
+
+- `getFileTree` with default pattern returns known files, excludes gitignored
+- `getFileTree` with exclude pattern (`!**/*.spec.ts`) omits test files
+- `readFiles` with 2 paths returns both labeled sections
+- `readFiles` with a gitignored path returns access denied for that entry, succeeds for others
+- `readFiles` with a nonexistent path returns error label, continues
+
+---
+
+## Implementation Order
+
+1. `lib/tools.ts` — add `getFileTree` and `readFiles`, update `allTools`
+2. `lib/agents.ts` — import new tools, update Researcher tool list + instructions
+3. `tests/tools.spec.ts` — tests for new tools
+4. Run `make check` — lint, typecheck, unit tests
+5. Smoke test: `npm run dev -- --verbose --output /tmp/test-readme.md --stats-output /tmp/stats.json` in a mid-sized repo, confirm call count
+6. Run eval: `cd evals && uv run pytest test_express_server.py::test_tool_call_efficiency -v` — should pass at ≤ 15
+
+## Expected Impact
+
+Baseline measured against express-server dataset (2026-03-03):
+
+| Tool pattern | Baseline (measured) | After |
+|---|---|---|
+| Repo traversal | 6 `list_directory` | 1 `get_file_tree` |
+| File reads | 13 `read_file` | 3–4 `read_files` (batches of 4–5) |
+| **Total** | **19** | **~6–8** |
+
+Budget threshold: ≤ 15 (eval test passes when total ≤ 15).
+
+## Backward Compatibility
+
+- `listDirectory` and `readFile` remain in `allTools` and unchanged — `DetailFetcher` continues using them unmodified
+- No changes to `diffTools` or the diff workflow agents
+- New tools are additive; no existing tool signatures change

--- a/docs/plans/plan-tool-call-stats-tracking-for-eval-efficiency-metric.md
+++ b/docs/plans/plan-tool-call-stats-tracking-for-eval-efficiency-metric.md
@@ -1,0 +1,253 @@
+# Plan: Tool Call Stats Tracking for Eval Efficiency Metric
+
+## Context
+
+The rereadme Researcher agent makes 25+ tool calls per run, causing OpenAI 429 TPM rate limit errors. Before optimizing with batch tools (`get_file_tree`, `read_files`), we need a measurable metric that:
+1. Emits a structured stats JSON per run (kept in `evals/results/` for inspection)
+2. Asserts in evals that total tool calls stay within a budget — failing at the current ~25 baseline, passing after optimization
+
+Data flow: `runner.ts` counts events → `script.ts` writes `--stats-output` JSON → `conftest.py` reads JSON → test files assert budget.
+
+---
+
+## File 1: `lib/runner.ts`
+
+### 1a. Add `WorkflowStats` interface (after imports, before `summarizeToolCall`)
+
+```typescript
+export interface WorkflowStats {
+  toolCallCount: number;
+  toolCallsByAgent: Record<string, number>;
+  toolCallsByTool: Record<string, number>;
+}
+```
+
+### 1b. Change `attachToolLogger` signature — add `agentName` + shared `stats` param, increment counters
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function attachToolLogger(agent: Agent<unknown, any>, agentName: string, stats: WorkflowStats): void {
+  agent.on('agent_tool_start', (_ctx, _tool, details) => {
+    const tc = details.toolCall;
+    if (tc.type !== 'function_call') return;
+    const summary = summarizeToolCall(tc.name, tc.arguments);
+    log.toolCall(`→ ${tc.name}${summary ? `  ${summary}` : ''}`);
+    stats.toolCallCount += 1;
+    stats.toolCallsByAgent[agentName] = (stats.toolCallsByAgent[agentName] ?? 0) + 1;
+    stats.toolCallsByTool[tc.name] = (stats.toolCallsByTool[tc.name] ?? 0) + 1;
+  });
+}
+```
+
+### 1c. Inside `runDiffWorkflow` — update the two `attachToolLogger` calls with throwaway stats
+
+```typescript
+const _diffStats: WorkflowStats = { toolCallCount: 0, toolCallsByAgent: {}, toolCallsByTool: {} };
+attachToolLogger(diffAnalyzer, 'DiffAnalyzer', _diffStats);
+attachToolLogger(readmePatcher, 'ReadmePatcher', _diffStats);
+```
+
+### 1d. Inside `runAgentWorkflow` — allocate stats, thread into loggers, return alongside readme/agents
+
+- Update return type: `Promise<{ readme: string; agents?: string; stats: WorkflowStats }>`
+- Allocate after agents created, before first `attachToolLogger` call:
+  ```typescript
+  const stats: WorkflowStats = { toolCallCount: 0, toolCallsByAgent: {}, toolCallsByTool: {} };
+  attachToolLogger(researcher, 'Researcher', stats);
+  attachToolLogger(detailFetcher, 'DetailFetcher', stats);
+  ```
+- Update the final return:
+  ```typescript
+  return { readme: stripFences(readme), agents: agents ? stripFences(agents) : undefined, stats };
+  ```
+
+---
+
+## File 2: `script.ts`
+
+### 2a. Update import — add `WorkflowStats` type import from runner
+
+```typescript
+import { runAgentWorkflow, runDiffWorkflow, type WorkflowStats } from './lib/runner.js'
+```
+
+### 2b. Add `STATS_OUTPUT` constant (after line 31, with other output flags)
+
+```typescript
+const STATS_OUTPUT = typeof args['stats-output'] === 'string' ? args['stats-output'] : undefined
+```
+
+### 2c. Add `workflowStats` declaration alongside `readmeContent`/`agentsContent` (lines 293–294)
+
+```typescript
+let readmeContent: string
+let agentsContent: string | undefined
+let workflowStats: WorkflowStats | undefined
+```
+
+### 2d. Capture stats inside the inner try block (after line 301 `agentsContent = result.agents`)
+
+```typescript
+workflowStats = result.stats
+```
+
+### 2e. Write stats JSON after the inner try/catch block, before `// Write README` (after line 308)
+
+```typescript
+// Write stats JSON if requested
+if (STATS_OUTPUT && workflowStats !== undefined) {
+  await fs.writeFile(STATS_OUTPUT, JSON.stringify(workflowStats, null, 2) + '\n')
+  log.detail(`Stats written to ${STATS_OUTPUT}`)
+}
+```
+
+### 2f. Add `--stats-output` to `showHelp()` options list
+
+```
+  --stats-output FILE       Write tool call stats JSON to the specified file
+```
+
+---
+
+## File 3: `evals/conftest.py`
+
+### 3a. Add `import json` to imports block (top of file)
+
+### 3b. Add `RunResult` dataclass after `CiRunResult`
+
+```python
+@dataclass
+class RunResult:
+    readme: str
+    agents: str
+    stats: dict  # type: ignore[type-arg]
+```
+
+### 3c. Rewrite `_express_server_run` fixture
+
+Key changes from current implementation:
+- Return type: `RunResult` (was `tuple[str, str]`)
+- Move `results_dir` creation and `timestamp` generation to **before** the subprocess call (needed to pass `--stats-output` path)
+- Add `--stats-output`, `stats_output_path` pointing directly to `results/express-server-stats-{timestamp}.json`
+- After subprocess succeeds, read stats JSON: `stats_data = json.load(f) if os.path.exists(stats_output_path) else {}`
+- Return `RunResult(readme=readme_content, agents=agents_content, stats=stats_data)`
+- Stats file goes directly into `results/` (not dataset dir) — no cleanup needed for it
+
+Stats path: `os.path.join(results_dir, f"express-server-stats-{timestamp}.json")`
+
+Subprocess args addition:
+```python
+"--stats-output",
+stats_output_path,
+```
+
+### 3d. Update `generated_readme` and `generated_agents_express_server` fixtures (tuple → attribute)
+
+```python
+@pytest.fixture(scope="session")
+def generated_readme(_express_server_run: RunResult) -> str:
+    return _express_server_run.readme
+
+@pytest.fixture(scope="session")
+def generated_agents_express_server(_express_server_run: RunResult) -> str:
+    return _express_server_run.agents
+```
+
+### 3e. Add `tool_call_stats_express_server` fixture (after `generated_agents_express_server`)
+
+```python
+@pytest.fixture(scope="session")
+def tool_call_stats_express_server(_express_server_run: RunResult) -> dict:  # type: ignore[type-arg]
+    return _express_server_run.stats
+```
+
+### 3f. Mirror all of 3c–3e for `_rereadme_run`
+
+- Stats path: `rereadme-stats-{timestamp}.json`
+- Update `generated_readme_rereadme`, `generated_agents_rereadme` to use `.readme` / `.agents`
+- Add `tool_call_stats_rereadme` fixture
+
+---
+
+## File 4: `evals/test_express_server.py`
+
+Append after `test_agents_golden_similarity` (currently last test, line 147):
+
+```python
+TOOL_CALL_BUDGET = 15
+
+
+def test_tool_call_efficiency(tool_call_stats_express_server: dict) -> None:  # type: ignore[type-arg]
+    """Total tool calls must stay within budget to prevent 429 rate limit errors.
+
+    Intentionally fails at ~25 calls (current baseline). Expected to pass
+    after batch tool optimization reduces calls to <= 15.
+    """
+    stats = tool_call_stats_express_server
+    total = stats.get("toolCallCount", 0)
+    assert total <= TOOL_CALL_BUDGET, (
+        f"Tool call count {total} exceeds budget of {TOOL_CALL_BUDGET}.\n"
+        f"Per-agent: {stats.get('toolCallsByAgent', {})}\n"
+        f"Per-tool:  {stats.get('toolCallsByTool', {})}"
+    )
+```
+
+---
+
+## File 5: `evals/test_rereadme.py`
+
+Identical append — only difference is fixture name `tool_call_stats_rereadme`:
+
+```python
+TOOL_CALL_BUDGET = 15
+
+
+def test_tool_call_efficiency(tool_call_stats_rereadme: dict) -> None:  # type: ignore[type-arg]
+    """Total tool calls must stay within budget to prevent 429 rate limit errors.
+
+    Intentionally fails at ~25 calls (current baseline). Expected to pass
+    after batch tool optimization reduces calls to <= 15.
+    """
+    stats = tool_call_stats_rereadme
+    total = stats.get("toolCallCount", 0)
+    assert total <= TOOL_CALL_BUDGET, (
+        f"Tool call count {total} exceeds budget of {TOOL_CALL_BUDGET}.\n"
+        f"Per-agent: {stats.get('toolCallsByAgent', {})}\n"
+        f"Per-tool:  {stats.get('toolCallsByTool', {})}"
+    )
+```
+
+---
+
+## Implementation Order
+
+1. `lib/runner.ts` — defines `WorkflowStats`, updates signatures
+2. `script.ts` — imports type, adds flag, writes JSON
+3. `evals/conftest.py` — reads JSON, exposes via fixtures
+4. `evals/test_express_server.py` + `evals/test_rereadme.py` — assert budget
+
+## Backward Compatibility
+
+All 8 existing tests in each file consume only the leaf string fixtures (`generated_readme`, `generated_agents_express_server`, etc.), whose return types remain `str`. No existing test function signatures change.
+
+## Verification
+
+After implementation:
+1. `make typecheck-ts` — catches any interface/type mismatches
+2. `make lint-ts` — ESLint clean
+3. Manual smoke: `npm run dev -- --output /tmp/test-readme.md --stats-output /tmp/stats.json` in a test repo, inspect `/tmp/stats.json`
+4. Full eval (when API quota allows): `cd evals && uv run pytest test_express_server.py::test_tool_call_efficiency -v` — expect failure at ~25 calls with breakdown in message
+5. After batch tool optimization: same test passes at ≤ 15
+
+## Results Dir Naming (post-plan)
+
+Stats files land alongside existing artifacts:
+```
+evals/results/
+  express-server-20260303T120000.md
+  express-server-AGENTS-20260303T120000.md
+  express-server-stats-20260303T120000.json   ← new
+  rereadme-20260303T120000.md
+  rereadme-AGENTS-20260303T120000.md
+  rereadme-stats-20260303T120000.json         ← new
+```

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@openai/agents';
 import { RECOMMENDED_PROMPT_PREFIX } from '@openai/agents-core/extensions';
 import { z } from 'zod';
-import { listDirectory, readFile, searchCode, getStructure, diffTools } from './tools.js';
+import { listDirectory, readFile, searchCode, getStructure, getFileTree, readFiles, diffTools } from './tools.js';
 
 export const DiffAnalysisSchema = z.object({
   significant: z.boolean().describe('Whether this diff warrants a README update'),
@@ -187,19 +187,23 @@ Additional rules:
     model,
     instructions: `${RECOMMENDED_PROMPT_PREFIX} You are a repository researcher. Your job is to explore the repository structure AND analyze file contents in a single pass. Work in two phases:
 
-**Phase 1 — Explore structure**
-Navigate the repository and identify key files:
-- package.json, Cargo.toml, pyproject.toml, go.mod, or other manifest files
+**Phase 1 — Map the repo structure**
+Call get_file_tree once with ["**/*"] to get the full file list. You now have the complete repo map — do NOT make further list_directory calls.
+
+From the file list, identify key files to read:
+- Manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, etc.)
 - Entry points and main source files
-- Configuration files (tsconfig, webpack, docker, CI/CD)
-- Container/dev environment configs (Dockerfile, docker-compose.yml, .devcontainer/)
-- Test files and test configuration
-- Documentation files
+- Configuration files (tsconfig, Dockerfile, docker-compose, CI/CD, .devcontainer/)
+- Documentation files (README, docs/)
 
-Start by listing the root directory, then explore important subdirectories including hidden directories like .devcontainer/.
+Skip test files, lock files, and generated output — they don't contribute README content.
 
-**Phase 2 — Extract content**
-Read the files you discovered and extract facts for the README. The template below is the single source of truth for what sections exist, what each section needs, and how the output will be organized. Each template section contains blockquote guidance describing the required content — use that as your checklist.
+**Phase 2 — Read key files in batches**
+Use read_files to read 4–6 related files per call (e.g., manifest + entry points together, then config files together). Use read_file only for single follow-up lookups. Use get_structure instead of read_files for large source files when you only need exported signatures.
+
+Target ≤ 4 read_files calls total. Stop reading once you have enough to populate every template section — do not read files for completeness alone.
+
+The template below is the single source of truth for what sections exist, what each section needs, and how the output will be organized. Each template section contains blockquote guidance describing the required content — use that as your checklist.
 
 Do NOT invent your own sections or headings. Organize your findings under the exact headings from the template.
 
@@ -209,7 +213,7 @@ README Template:
 ${readmeTemplate}
 
 When done, output your findings as a structured technical summary using the exact headings from the template above. Under each heading, list the specific facts you found and where you found them (file paths). Do not fabricate details — only report what you actually read.`,
-    tools: [listDirectory, readFile, searchCode, getStructure],
+    tools: [getFileTree, readFiles, listDirectory, readFile, searchCode, getStructure],
     handoffDescription:
       'Explore repository structure and analyze file contents',
   });

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -213,7 +213,7 @@ README Template:
 ${readmeTemplate}
 
 When done, output your findings as a structured technical summary using the exact headings from the template above. Under each heading, list the specific facts you found and where you found them (file paths). Do not fabricate details — only report what you actually read.`,
-    tools: [getFileTree, readFiles, listDirectory, readFile, searchCode, getStructure],
+    tools: [getFileTree, readFiles, searchCode, getStructure],
     handoffDescription:
       'Explore repository structure and analyze file contents',
   });

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -4,6 +4,12 @@ import { stripFences } from './readme-utils.js';
 import * as fs from 'node:fs';
 import * as log from './logger.js';
 
+export interface WorkflowStats {
+  toolCallCount: number;
+  toolCallsByAgent: Record<string, number>;
+  toolCallsByTool: Record<string, number>;
+}
+
 function summarizeToolCall(name: string, argsJson: string): string {
   try {
     const args = JSON.parse(argsJson) as Record<string, unknown>;
@@ -23,12 +29,15 @@ function summarizeToolCall(name: string, argsJson: string): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function attachToolLogger(agent: Agent<unknown, any>): void {
+function attachToolLogger(agent: Agent<unknown, any>, agentName: string, stats: WorkflowStats): void {
   agent.on('agent_tool_start', (_ctx, _tool, details) => {
     const tc = details.toolCall;
     if (tc.type !== 'function_call') return;
     const summary = summarizeToolCall(tc.name, tc.arguments);
     log.toolCall(`→ ${tc.name}${summary ? `  ${summary}` : ''}`);
+    stats.toolCallCount += 1;
+    stats.toolCallsByAgent[agentName] = (stats.toolCallsByAgent[agentName] ?? 0) + 1;
+    stats.toolCallsByTool[tc.name] = (stats.toolCallsByTool[tc.name] ?? 0) + 1;
   });
 }
 
@@ -53,8 +62,9 @@ export async function runDiffWorkflow(
   const { model, inputFile, baseRef, headRef } = options;
 
   const { diffAnalyzer, readmePatcher } = createDiffAgents(model);
-  attachToolLogger(diffAnalyzer);
-  attachToolLogger(readmePatcher);
+  const _diffStats: WorkflowStats = { toolCallCount: 0, toolCallsByAgent: {}, toolCallsByTool: {} };
+  attachToolLogger(diffAnalyzer, 'DiffAnalyzer', _diffStats);
+  attachToolLogger(readmePatcher, 'ReadmePatcher', _diffStats);
 
   return withTrace('ReReadme Diff Workflow', async () => {
     // Step 1: DiffAnalyzer classifies the changes
@@ -110,12 +120,13 @@ export interface AgentWorkflowOptions {
 
 export async function runAgentWorkflow(
   options: AgentWorkflowOptions,
-): Promise<{ readme: string; agents?: string }> {
+): Promise<{ readme: string; agents?: string; stats: WorkflowStats }> {
   const { model, readmeTemplate, agentsTemplate } = options;
 
   const { researcher, templateEnforcer, detailFetcher, agentsDocWriter } = createAgents(model, readmeTemplate, agentsTemplate);
-  attachToolLogger(researcher);
-  attachToolLogger(detailFetcher);
+  const stats: WorkflowStats = { toolCallCount: 0, toolCallsByAgent: {}, toolCallsByTool: {} };
+  attachToolLogger(researcher, 'Researcher', stats);
+  attachToolLogger(detailFetcher, 'DetailFetcher', stats);
 
   const initialPrompt = 'Generate a README.md for this repository.';
 
@@ -156,5 +167,6 @@ export async function runAgentWorkflow(
   return {
     readme: stripFences(readme),
     agents: agents ? stripFences(agents) : undefined,
+    stats,
   };
 }

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -161,7 +161,73 @@ export const getStructure = tool({
   },
 });
 
-export const allTools = [listDirectory, readFile, searchCode, getStructure];
+export const getFileTree = tool({
+  name: 'get_file_tree',
+  description:
+    'Get a flat list of all repo files matching glob patterns. Faster than repeated list_directory calls. ' +
+    'Use exclude patterns (prefix with !) to filter noise, e.g. ["**/*", "!**/*.spec.ts", "!tests/**"]. ' +
+    'Returns one relative path per line.',
+  parameters: z.object({
+    patterns: z
+      .array(z.string())
+      .default(['**/*'])
+      .describe('Globby include/exclude patterns. Prefix with ! to exclude.'),
+  }),
+  execute: async (input) => {
+    const files = await globby(input.patterns, {
+      cwd: ROOT,
+      gitignore: true,
+      dot: true,
+      ignore: ['.git/**', 'node_modules/**'],
+    });
+    return files.length > 0 ? files.join('\n') : 'No files matched.';
+  },
+});
+
+export const readFiles = tool({
+  name: 'read_files',
+  description:
+    'Read multiple files at once. Prefer this over repeated read_file calls when you know which files you need. ' +
+    "Returns each file's content labeled with its path. Max 8 files per call.",
+  parameters: z.object({
+    paths: z
+      .array(z.string())
+      .max(8)
+      .describe('Relative paths from repo root'),
+    maxLinesEach: z
+      .number()
+      .max(500)
+      .default(300)
+      .describe('Max lines to return per file'),
+  }),
+  execute: async (input) => {
+    const isIgnored = await isGitIgnored({ cwd: ROOT });
+    const results: string[] = [];
+    for (const p of input.paths) {
+      const filePath = safePath(p);
+      if (isIgnored(path.relative(ROOT, filePath))) {
+        results.push(`### ${p}\n[Access denied: gitignored]`);
+        continue;
+      }
+      try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n').slice(0, input.maxLinesEach);
+        const truncated = lines.length < content.split('\n').length;
+        const header = `### ${p}`;
+        const body = lines.join('\n');
+        const footer = truncated
+          ? `\n[... truncated at ${input.maxLinesEach} lines]`
+          : '';
+        results.push(`${header}\n${body}${footer}`);
+      } catch {
+        results.push(`### ${p}\n[Error: file not found or unreadable]`);
+      }
+    }
+    return results.join('\n\n---\n\n');
+  },
+});
+
+export const allTools = [listDirectory, readFile, searchCode, getStructure, getFileTree, readFiles];
 
 export const gitDiffStat = tool({
   name: 'git_diff_stat',

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -15,6 +15,10 @@ function safePath(relativePath: string): string {
   return resolved;
 }
 
+/**
+ * @deprecated Superseded by `getFileTree`, which returns the full repo file list in one call.
+ * Retained for `DetailFetcher` and backward compatibility.
+ */
 export const listDirectory = tool({
   name: 'list_directory',
   description:
@@ -41,6 +45,10 @@ export const listDirectory = tool({
   },
 });
 
+/**
+ * @deprecated Superseded by `readFiles`, which batches multiple reads into one tool call.
+ * Retained for `DetailFetcher` and backward compatibility.
+ */
 export const readFile = tool({
   name: 'read_file',
   description:

--- a/script.ts
+++ b/script.ts
@@ -3,7 +3,7 @@
 // rereadme - CLI tool to automatically update README files
 import { $, fs, path, argv } from 'zx'
 import { fileURLToPath } from 'url'
-import { runAgentWorkflow, runDiffWorkflow } from './lib/runner.js'
+import { runAgentWorkflow, runDiffWorkflow, type WorkflowStats } from './lib/runner.js'
 import { renderSuggestions, applyPatches } from './lib/readme-utils.js'
 import { validateTemplate } from './lib/validate.js'
 import * as log from './lib/logger.js'
@@ -29,6 +29,7 @@ const HEAD_REF = typeof args['head-ref'] === 'string' ? args['head-ref'] : 'HEAD
 const CI_OUTPUT = typeof args['ci-output'] === 'string' ? args['ci-output'] : 'README-suggestions.md'
 const CUSTOM_README_TEMPLATE = typeof args.template === 'string' ? args.template : undefined
 const CUSTOM_AGENTS_TEMPLATE = typeof args['agents-template'] === 'string' ? args['agents-template'] : undefined
+const STATS_OUTPUT = typeof args['stats-output'] === 'string' ? args['stats-output'] : undefined
 
 async function checkGitRepo(): Promise<boolean> {
   try {
@@ -241,7 +242,7 @@ export async function updateReadme(content: string): Promise<void> {
 
 export async function formatReadme(): Promise<void> {
   log.detail(`Formatting ${OUTPUT_FILE} with markdownlint`)
-  const fixResult = await $({ nothrow: true })`markdownlint --fix ${OUTPUT_FILE}`
+  const fixResult = await $({ nothrow: true })`markdownlint --fix --disable MD013 -- ${OUTPUT_FILE}`
   if (fixResult.exitCode === 0) {
     log.detail(`${OUTPUT_FILE} formatted`)
   } else {
@@ -292,6 +293,7 @@ export async function runWorkflow(): Promise<void> {
     log.setSpinner(spinner)
     let readmeContent: string
     let agentsContent: string | undefined
+    let workflowStats: WorkflowStats | undefined
     try {
       const result = await runAgentWorkflow({
         model: OPENAI_MODEL,
@@ -299,12 +301,19 @@ export async function runWorkflow(): Promise<void> {
       })
       readmeContent = result.readme
       agentsContent = result.agents
+      workflowStats = result.stats
       log.setSpinner(null)
       spinner.stop('Agent workflow complete')
     } catch (e) {
       log.setSpinner(null)
       spinner.stop('Agent workflow failed')
       throw e
+    }
+
+    // Write stats JSON if requested
+    if (STATS_OUTPUT && workflowStats !== undefined) {
+      await fs.writeFile(STATS_OUTPUT, JSON.stringify(workflowStats, null, 2) + '\n')
+      log.detail(`Stats written to ${STATS_OUTPUT}`)
     }
 
     // Write README
@@ -331,7 +340,7 @@ export async function runWorkflow(): Promise<void> {
       log.step(`Writing ${AGENTS_OUTPUT_FILE}`)
       await fs.writeFile(AGENTS_OUTPUT_FILE, agentsContent.trim() + '\n')
       log.detail(`${AGENTS_OUTPUT_FILE} written`)
-      const agentsFix = await $({ nothrow: true })`markdownlint --fix ${AGENTS_OUTPUT_FILE}`
+      const agentsFix = await $({ nothrow: true })`markdownlint --fix --disable MD013 -- ${AGENTS_OUTPUT_FILE}`
       if (agentsFix.exitCode !== 0) {
         log.warn(`Some markdown issues in ${AGENTS_OUTPUT_FILE} may need manual fixing`)
       }

--- a/tests/tools.spec.ts
+++ b/tests/tools.spec.ts
@@ -146,6 +146,57 @@ describe("git_diff", () => {
     })
 })
 
+describe("get_file_tree", () => {
+    it("should return known files with default pattern", async () => {
+        const result = await invokeTool(tools.getFileTree, { patterns: ['**/*'] })
+        expect(result).toContain('package.json')
+        expect(result).toContain('lib/tools.ts')
+    })
+
+    it("should exclude files matching exclude patterns", async () => {
+        const result = await invokeTool(tools.getFileTree, { patterns: ['**/*', '!**/*.spec.ts'] })
+        expect(result).not.toContain('.spec.ts')
+        expect(result).toContain('lib/tools.ts')
+    })
+
+    it("should return 'No files matched.' for unmatched pattern", async () => {
+        const result = await invokeTool(tools.getFileTree, { patterns: ['**/*.neverexists'] })
+        expect(result).toBe('No files matched.')
+    })
+})
+
+describe("read_files", () => {
+    it("should return labeled content for multiple paths", async () => {
+        const result = await invokeTool(tools.readFiles, { paths: ['package.json', 'lib/tools.ts'] })
+        expect(result).toContain('### package.json')
+        expect(result).toContain('### lib/tools.ts')
+        expect(result).toContain('"name": "rereadme"')
+    })
+
+    it("should return access denied for gitignored paths", async () => {
+        const gitignored = 'test-secret.backup-gitignore-rf'
+        nodeFs.writeFileSync(gitignored, 'SECRET=1\n')
+        try {
+            const result = await invokeTool(tools.readFiles, { paths: [gitignored, 'package.json'] })
+            expect(result).toContain('[Access denied: gitignored]')
+            expect(result).toContain('### package.json')
+        } finally {
+            if (nodeFs.existsSync(gitignored)) nodeFs.unlinkSync(gitignored)
+        }
+    })
+
+    it("should return error label for nonexistent paths", async () => {
+        const result = await invokeTool(tools.readFiles, { paths: ['nonexistent-file-xyz.ts', 'package.json'] })
+        expect(result).toContain('[Error: file not found or unreadable]')
+        expect(result).toContain('### package.json')
+    })
+
+    it("should truncate files exceeding maxLinesEach", async () => {
+        const result = await invokeTool(tools.readFiles, { paths: ['lib/tools.ts'], maxLinesEach: 5 })
+        expect(result).toContain('[... truncated at 5 lines]')
+    })
+})
+
 describe("diffTools export", () => {
     it("should export diffTools array", async () => {
         expect(tools.diffTools).toBeDefined()


### PR DESCRIPTION
# Feat: Add batch tools to reduce Researcher tool call count

## Summary

Adds `get_file_tree` and `read_files` batch tools so the Researcher agent can map the entire repo and read all key files in two tool calls instead of nineteen. Also removes the now-redundant `list_directory` and `read_file` tools from the Researcher's tool list and marks them deprecated in favour of the batch alternatives.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `lib/tools.ts`: add `getFileTree` (globby-based full file list in one call) and `readFiles` (batch multi-file reader, up to 8 files per call); update `allTools`; mark `listDirectory` and `readFile` as `@deprecated`
- `lib/agents.ts`: update Researcher tools to `[getFileTree, readFiles, searchCode, getStructure]`; rewrite Phase 1/2 instructions to use the new tools and target ≤4 `read_files` calls
- `tests/tools.spec.ts`: add 7 tests covering `get_file_tree` (default pattern, exclude pattern, no match) and `read_files` (multi-path, gitignored path, nonexistent path, truncation)
- `docs/plans/plan-batch-tools-reduce-tool-calls.md`: implementation plan (added in prior commit on this branch)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Ran against `evals/datasets/express-server` with `--stats-output`:

| | Baseline | After |
|---|---|---|
| `list_directory` | 6 | 0 |
| `read_file` | 13 | 0 |
| `get_file_tree` | — | 1 |
| `read_files` | — | 1 |
| **Total** | **19** | **2** |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)