### PR TITLE
chore: bump ReReadme action ref to v0.0.3

### DIFF
--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.2
+      - uses: cjlludwig/ReReadme@v0.0.3
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           verbose: 'true'

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.2
+      - uses: cjlludwig/ReReadme@v0.0.3
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 # ⚠️ README-suggestions.md written on drift

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.2
+      - uses: cjlludwig/ReReadme@v0.0.3
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 # ⚠️ README-suggestions.md written on drift


### PR DESCRIPTION
# Chore: bump ReReadme action ref to v0.0.3

## Summary

Updates all references to the `cjlludwig/ReReadme` GitHub Action from `v0.0.2` to `v0.0.3`. This keeps the CI workflow and documentation in sync with the latest published action version.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `.github/workflows/readme-ci.yml`: updated action ref from `v0.0.2` to `v0.0.3`
- `README.md`: updated example workflow snippet to use `v0.0.3`
- `docs/workflows.md`: updated example workflow snippet to use `v0.0.3`

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)