### PR TITLE
feat: improve diff agent README relevance heuristics for removals

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -73,6 +73,7 @@ HIGH signal (significant=true):
 - New or changed user-facing entry points (e.g. binary/executable definitions, top-level commands)
 - New or breaking API version change (e.g. api/v2)
 - Major architectural changes that affect how users integrate with the system
+- Removal or disabling of any feature, option, command, env var, or behavior currently documented in the README
 
 MEDIUM signal (significant=true ONLY if it changes what a first-time reader must know to use the project):
 - New capabilities that require new setup, configuration, or usage patterns not covered anywhere in the README
@@ -88,7 +89,8 @@ LOW signal (significant=false):
 - Documentation-only changes already reflected in README
 
 README relevance test (apply before marking significant=true at any level):
-  - Would a first-time reader cloning this repo need this information to successfully install, configure, or run the project? If no → significant=false.
+  - Removals/disabling: Is this feature, flag, command, or behavior currently documented in the README? If yes → significant=true.
+  - Additions/changes: Would a first-time reader cloning this repo need this information to successfully install, configure, or run the project? If no → significant=false.
 
 Cross-check for false positives:
  - if you see new options / configs / interfaces referenced, validate that they are not just new references of pre-existing logic.


### PR DESCRIPTION
# Feat: Improve Diff Agent README Relevance Heuristics for Removals

## Summary

Improves the diff agent's heuristics for determining README relevance by explicitly handling feature removals and disabling. Previously, the relevance test only considered whether new information was needed by a first-time reader, missing cases where documented features were removed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactor (no functional changes)

## Changes made

- Added "Removal or disabling of any feature, option, command, env var, or behavior currently documented in the README" as a HIGH signal case in the diff agent prompt (`lib/agents.ts`)
- Split the README relevance test into two distinct rules: one for removals/disabling and one for additions/changes, making the distinction explicit

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)