### PR TITLE
ci: add publish workflow and npm release infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,24 @@ jobs:
         env:
           OPENAI_API_KEY: foo
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - run: npm ci
+
+      - name: Pack and install from tarball
+        run: |
+          npm pack
+          npm install -g ./rereadme-*.tgz
+
+      - name: Smoke test CLI
+        run: rereadme --help
+        env:
+          OPENAI_API_KEY: foo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push tags and self-update commit
+      id-token: write   # required for npm provenance attestation
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # required to push tags
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - name: Lint package
+        run: npx publint
+
+      - name: Check if version changed
+        id: version_check
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view rereadme version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce pack size < 500 kB
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          npm pack
+          TARBALL=$(ls rereadme-*.tgz)
+          SIZE=$(stat -c%s "$TARBALL")
+          echo "Pack size: ${SIZE} bytes"
+          rm "$TARBALL"
+          [ "$SIZE" -lt 512000 ] || (echo "ERROR: ${SIZE} bytes exceeds 500 kB limit" && exit 1)
+
+      - name: Publish dry run
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag release
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "v${VERSION}"
+          git tag -f "v${MAJOR}"
+          git push origin "v${VERSION}"
+          git push origin "v${MAJOR}" --force
+
+      - name: Create GitHub Release
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes
+
+      - name: Update readme-ci.yml to new version
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+        run: |
+          sed -i "s|cjlludwig/ReReadme@v[0-9]*\.[0-9]*\.[0-9]*|cjlludwig/ReReadme@v${VERSION}|g" \
+            .github/workflows/readme-ci.yml
+          git add .github/workflows/readme-ci.yml
+          git diff --cached --quiet || git commit -m "chore: update GHA ref to v${VERSION} [skip ci]"
+          git pull --rebase
+          git push

--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.3
+      - uses: cjlludwig/ReReadme@v0.0.4
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           verbose: 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint-ts lint-md lint-py typecheck-ts typecheck-py deps-ts deps-py test check fix
+.PHONY: lint-ts lint-md lint-py lint-pkg typecheck-ts typecheck-py deps-ts deps-py test check fix
 
 -include local/Makefile
 
@@ -14,6 +14,10 @@ lint-py:
 	@echo "==> Ruff"
 	cd evals && uv run ruff check .
 
+lint-pkg:
+	@echo "==> publint"
+	npx publint
+
 typecheck-ts:
 	@echo "==> tsc --noEmit"
 	npx tsc --noEmit
@@ -28,16 +32,16 @@ test:
 
 deps-ts:
 	@echo "==> depcheck"
-	npx depcheck --ignores="depcheck,@types/fs-extra,@jest/globals,@openai/agents-core,markdownlint-cli" --ignore-patterns="dist,evals"
+	npx depcheck --ignores="depcheck,@types/fs-extra,@jest/globals,@openai/agents-core,markdownlint-cli,publint" --ignore-patterns="dist,evals"
 
 deps-py:
 	@echo "==> deptry"
 	cd evals && uv run deptry .
 
-pre-commit: lint-py typecheck-ts typecheck-py deps-ts deps-py
+pre-commit: lint-pkg lint-py typecheck-ts typecheck-py deps-ts deps-py
 	@echo "==> All checks passed"
 
-check: lint-ts lint-md lint-py typecheck-ts typecheck-py deps-ts deps-py
+check: lint-ts lint-md lint-py lint-pkg typecheck-ts typecheck-py deps-ts deps-py
 	@echo "==> All checks passed"
 
 fix:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![Build](https://github.com/cjlludwig/ReReadme/actions/workflows/ci.yml/badge.svg)
 ![Last Commit](https://img.shields.io/github/last-commit/cjlludwig/ReReadme)
-<!-- Uncomment when published to npm: [![npm version](https://img.shields.io/npm/v/rereadme)](https://www.npmjs.com/package/rereadme) -->
+[![npm](https://img.shields.io/npm/v/rereadme)](https://www.npmjs.com/package/rereadme)
 
 `rereadme` is a CLI tool that refreshes `README.md` files by analyzing a repository and generating an updated README from a template using an AI agent workflow built on the OpenAI Agents SDK. It supports both a full regeneration mode and a PR-friendly CI mode that analyzes diffs and produces targeted patch suggestions.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,6 +90,29 @@ The **pre-commit hook** (installed automatically by `npm install` via husky) run
 
 A **PostToolUse hook** in `.claude/settings.json` runs `make check` after every file write or edit when working with Claude Code.
 
+## Releases
+
+Releases are triggered by bumping the version in `package.json` and pushing to `main`. The publish CI workflow detects the version change and handles everything automatically.
+
+**To cut a release:**
+
+```shell
+npm version patch   # 1.0.0 → 1.0.1  (bug fixes)
+npm version minor   # 1.0.0 → 1.1.0  (new features, backwards-compatible)
+npm version major   # 1.0.0 → 2.0.0  (breaking changes)
+git tag -d vX.Y.Z  # discard the local tag — CI creates it
+git push
+```
+
+`npm version` updates `package.json` and commits the change automatically. The push to `main` triggers `.github/workflows/publish.yml`, which:
+
+1. Publishes the package to npm with provenance attestation
+2. Creates git tags `vX.Y.Z` and floating `vX`
+3. Creates a GitHub Release with auto-generated notes from merged PR titles
+4. Commits a version bump to `.github/workflows/readme-ci.yml` so this repo uses the version it just released
+
+Verify the release at `https://www.npmjs.com/package/rereadme` and the GitHub Releases tab.
+
 ## Standards
 
 - **TypeScript** — typescript-eslint recommended + type-checked rules; no implicit `any`

--- a/docs/specs/publishing-ci.md
+++ b/docs/specs/publishing-ci.md
@@ -1,0 +1,253 @@
+# Publishing CI
+
+Automated GHA workflow that publishes the npm package and updates GHA version tags whenever a version bump lands on `main`.
+
+## Decisions Made
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Release trigger | Manual version bump in `package.json` → push to `main` | Explicit, no extra tooling, deterministic |
+| GHA tag strategy | Exact `vX.Y.Z` + floating `vX` major tag | Standard GitHub Marketplace convention |
+| Self-update | Yes — auto-commit `readme-ci.yml` version update | Dogfoods the action on every release |
+
+## Prerequisites (package.json fixes required before first publish)
+
+These must be fixed before the workflow can succeed. See the pre-publish checklist:
+
+1. **Add `files` whitelist** — package currently packs 50.5 MB (includes `evals/` datasets). Add to `package.json`:
+   ```json
+   "files": ["bin/", "lib/", "script.ts", "templates/", ".markdownlint.jsonc"]
+   ```
+2. **Move `tsx` to `dependencies`** — `bin/rereadme.js` spawns it at runtime; it's currently in `devDependencies`
+3. **Move `typescript` to `devDependencies`** — not used at runtime (tsx uses esbuild internally)
+4. **Fix `prepare` script** — `"prepare": "husky"` fails for users installing the package without a `.git` dir; change to `"prepare": "husky || true"`
+5. ~~**Add `LICENSE` file**~~ — **Done** (commit `be8ed1d`)
+6. **Add `provenance: true` to `publishConfig`** — `publishConfig` exists (`"access": "public"`) but is missing `provenance: true`. Update to:
+   ```json
+   "publishConfig": { "access": "public", "provenance": true }
+   ```
+   Setting `provenance: true` here (rather than a CLI flag) ensures it's always set and appears in `package.json` as documentation of intent.
+7. **Confirm `engines` field** — already present (`"node": ">=22.0.0"`); no change needed
+8. **Add `publint` to devDependencies** — static linter that validates `package.json` publish correctness (bin paths exist, `files` entries resolve, ESM/CJS consistency). Fast enough for pre-commit (<1s, file reads only). Add as `make lint-pkg` target and to the pre-commit hook alongside existing lint-staged checks.
+
+## README Badges
+
+Add to `README.md` header (after the title, before the description):
+
+```markdown
+[![npm](https://img.shields.io/npm/v/rereadme)](https://www.npmjs.com/package/rereadme)
+[![CI](https://github.com/cjlludwig/rereadme/actions/workflows/ci.yml/badge.svg)](https://github.com/cjlludwig/rereadme/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+```
+
+## Commented-Out Items to Resolve
+
+`ci.yml` currently has a placeholder for the real API key:
+
+```yaml
+OPENAI_API_KEY: foo
+# OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The `foo` value is intentional for `--check` (dependency validation only, no API call). Leave it as-is — the publish workflow does not run the tool, only `npm ci`. No change needed.
+
+## Secrets Required
+
+| Secret name | Where to set | What it is |
+|---|---|---|
+| `NPM_TOKEN` | GitHub repo Settings → Secrets → Actions | npm automation token with publish permission (create via npmjs.com → profile → Access Tokens → Generate New Token → Automation; the `npm token create --type automation` CLI flag is outdated as of npm v10+) |
+
+The existing `OPENAI_API_KEY` secret is already set and used by other workflows.
+
+## New File: `.github/workflows/publish.yml`
+
+```yaml
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push tags and self-update commit
+      id-token: write   # required for npm provenance attestation
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # required to push tags
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - name: Lint package
+        run: npx publint
+
+      - name: Check if version changed
+        id: version_check
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view rereadme version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce pack size < 500 kB
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          npm pack
+          TARBALL=$(ls rereadme-*.tgz)
+          SIZE=$(stat -c%s "$TARBALL")
+          echo "Pack size: ${SIZE} bytes"
+          rm "$TARBALL"
+          [ "$SIZE" -lt 512000 ] || (echo "ERROR: ${SIZE} bytes exceeds 500 kB limit" && exit 1)
+
+      - name: Publish dry run
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag release
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "v${VERSION}"
+          git tag -f "v${MAJOR}"
+          git push origin "v${VERSION}"
+          git push origin "v${MAJOR}" --force
+
+      - name: Create GitHub Release
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes
+
+      - name: Update readme-ci.yml to new version
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.local }}
+        run: |
+          sed -i "s|cjlludwig/ReReadme@v[0-9]*\.[0-9]*\.[0-9]*|cjlludwig/ReReadme@v${VERSION}|g" \
+            .github/workflows/readme-ci.yml
+          git add .github/workflows/readme-ci.yml
+          git diff --cached --quiet || git commit -m "chore: update GHA ref to v${VERSION} [skip ci]"
+          git pull --rebase
+          git push
+```
+
+## Modified File: `.github/workflows/ci.yml`
+
+Add a pack smoke test job that runs on every push/PR. Installs the CLI from the packed tarball (not `npm link`) to test the exact artifact users receive:
+
+```yaml
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - run: npm ci
+
+      - name: Pack and install from tarball
+        run: |
+          npm pack
+          npm install -g ./rereadme-*.tgz
+
+      - name: Smoke test CLI
+        run: rereadme --help
+        env:
+          OPENAI_API_KEY: foo
+```
+
+This is intentionally separate from the existing `install-and-cli` job (which uses `npm link`) so both the source and the packed artifact are tested. Too slow (~20–30s) for the pre-commit hook.
+
+## Workflow Logic
+
+```text
+push to main
+  └─ npm ci
+  └─ npx publint                    (always — gates on package validity)
+  └─ compare package.json version vs npm registry
+       ├─ same → skip (no release needed)
+       └─ different →
+            ├─ npm pack → assert size < 500 kB
+            ├─ npm publish --dry-run (smoke test before real publish)
+            ├─ npm publish --provenance
+            ├─ git tag -f vX.Y.Z
+            ├─ git tag -f vX (floating major)
+            ├─ git push tags
+            ├─ gh release create vX.Y.Z --generate-notes
+            └─ sed readme-ci.yml → commit "chore: update GHA ref to vX.Y.Z [skip ci]" → pull --rebase → push
+```
+
+## Release Workflow (Developer Steps)
+
+1. Make changes on a feature branch, open PR
+2. Merge to `main` (existing CI runs: install, lint, typecheck, test)
+3. Locally: `npm version patch|minor|major` (updates `package.json` and creates a local git tag — discard the local tag with `git tag -d vX.Y.Z` since CI will create it)
+4. Push to `main` — publish workflow fires automatically
+5. Verify: check npm registry + GitHub Releases tab for new tag
+
+Alternatively, manually edit the `version` field in `package.json` and push.
+
+## File Layout
+
+| File | Change |
+|---|---|
+| `.github/workflows/publish.yml` | **New** — the publish workflow |
+| `.github/workflows/ci.yml` | **Modified** — add `smoke-test` job |
+| `.github/workflows/readme-ci.yml` | **Manual update needed before first release** — currently pins `v0.0.3`, bump to `v0.0.4`; auto-updated thereafter |
+| `package.json` | **Modified** — `files`, add `provenance: true` to `publishConfig`, dependency moves, `prepare`, add `publint` to devDependencies, fix `homepage`/`bugs`/`repository` URLs (`connorludwig` → `cjlludwig`) |
+| `Makefile` | **Modified** — add `lint-pkg` target (`npx publint`), add to `check` and `pre-commit` |
+| `LICENSE` | **New** — MIT license text |
+| `README.md` | **Modified** — add npm, CI, and license badges |
+| `docs/development.md` | **Modified** — add release process section |
+
+## Acceptance Criteria
+
+### Deterministic
+
+- [ ] `npx publint` exits 0 with no errors
+- [ ] `npm pack --dry-run` shows ≤ 10 files, package size < 500 kB
+- [ ] `ci.yml` smoke-test job passes: pack → install from tarball → `rereadme --help`
+- [ ] `npm install -g rereadme` on a clean machine runs `rereadme --help` successfully
+- [ ] After merging a version bump PR, `npm view rereadme version` returns the new version within ~2 minutes
+- [ ] Git tags `vX.Y.Z` and `vX` exist on the release commit
+- [ ] `readme-ci.yml` is updated to `cjlludwig/ReReadme@vX.Y.Z` with a `[skip ci]` commit
+- [ ] A GitHub Release exists at `vX.Y.Z` with auto-generated notes listing merged PRs
+
+### Manual verification
+
+- [ ] A subsequent push to `main` without a version bump does not re-publish or re-tag
+- [ ] The floating `vX` tag resolves to the latest release commit (check with `git show v1`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "globby": "16.1.1",
         "markdownlint": "0.40.0",
         "picocolors": "1.1.1",
-        "typescript": "5.9.3",
+        "tsx": "4.21.0",
         "zod": "4.3.6",
         "zx": "8.8.5"
       },
@@ -33,7 +33,8 @@
         "husky": "^9.1.7",
         "jest": "^30.2.0",
         "lint-staged": "^16.2.7",
-        "tsx": "^4.21.0",
+        "publint": "^0.3.12",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.56.0"
       },
       "engines": {
@@ -598,7 +599,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -615,7 +615,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -632,7 +631,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -649,7 +647,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -666,7 +663,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,7 +679,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,7 +695,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,7 +711,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -734,7 +727,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,7 +743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -768,7 +759,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,7 +775,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -802,7 +791,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,7 +807,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -836,7 +823,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,7 +839,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,7 +855,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,7 +871,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,7 +887,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -921,7 +903,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,7 +919,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -955,7 +935,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,7 +951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,7 +967,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,7 +983,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,7 +999,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,6 +1896,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.4.tgz",
+      "integrity": "sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4295,7 +4283,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5093,7 +5080,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5212,7 +5198,6 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7616,6 +7601,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7931,6 +7926,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8239,6 +8241,28 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/publint": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.18.tgz",
+      "integrity": "sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.4",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8437,7 +8461,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -8531,6 +8554,19 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safer-buffer": {
@@ -9234,7 +9270,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -9305,6 +9340,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,16 @@
   ],
   "author": "Connor Ludwig",
   "license": "MIT",
-  "homepage": "https://github.com/connorludwig/rereadme#readme",
+  "homepage": "https://github.com/cjlludwig/rereadme#readme",
   "bugs": {
-    "url": "https://github.com/connorludwig/rereadme/issues"
+    "url": "https://github.com/cjlludwig/rereadme/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/connorludwig/rereadme.git"
+    "url": "git+https://github.com/cjlludwig/rereadme.git"
   },
-  "publishConfig": { "access": "public" },
+  "files": ["bin/", "lib/", "script.ts", "templates/", ".markdownlint.jsonc"],
+  "publishConfig": { "access": "public", "provenance": true },
 
   "scripts": {
     "dev": "tsx ./script.ts",
@@ -43,7 +44,7 @@
     "eval:report": "cd evals && NO_COLOR=1 uv run python evaluate.py",
     "eval:ci": "cd evals && uv run pytest test_ci_mode.py -v",
     "eval:all": "cd evals && uv run pytest -v",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@clack/prompts": "1.0.1",
@@ -51,7 +52,7 @@
     "globby": "16.1.1",
     "markdownlint": "0.40.0",
     "picocolors": "1.1.1",
-    "typescript": "5.9.3",
+    "tsx": "4.21.0",
     "zod": "4.3.6",
     "zx": "8.8.5"
   },
@@ -67,7 +68,8 @@
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "lint-staged": "^16.2.7",
-    "tsx": "^4.21.0",
+    "publint": "^0.3.12",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.56.0"
   },
   "engines": {


### PR DESCRIPTION
# ci: add publish workflow and npm release infrastructure

## Summary

Adds automated npm publishing CI that triggers on version bumps merged to `main`. Includes pack size enforcement, provenance attestation, git tagging, GitHub Release creation, and self-updating GHA ref. Also fixes `package.json` for correct publish output (files whitelist, dependency placement, `prepare` script) and adds a `smoke-test` job to CI that validates the packed tarball.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- Added `.github/workflows/publish.yml` — detects version bump on `main`, enforces <500 kB pack size, dry-runs then publishes to npm with provenance, creates `vX.Y.Z` + `vX` git tags, creates a GitHub Release, and commits a self-update to `readme-ci.yml`
- Added `smoke-test` job to `.github/workflows/ci.yml` — packs the tarball and installs it globally to validate the exact artifact users receive
- Fixed `package.json`: added `files` whitelist, moved `tsx` to `dependencies`, moved `typescript` to `devDependencies`, added `publint` to devDeps, fixed `prepare` script to `husky || true`, added `provenance: true` to `publishConfig`, corrected `homepage`/`bugs`/`repository` URLs
- Added `lint-pkg` target to `Makefile` (`npx publint`); added to `check` and `pre-commit` targets
- Added release process section to `docs/development.md`
- Added `docs/specs/publishing-ci.md` with full spec and acceptance criteria

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Verified locally: `make lint-pkg` passes, `npm pack --dry-run` shows correct file set. Smoke-test job will run on CI.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)