### PR TITLE
fix: remove redundant NODE_AUTH_TOKEN env from publish steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,14 +54,10 @@ jobs:
       - name: Publish dry run
         if: steps.version_check.outputs.changed == 'true'
         run: npm publish --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         if: steps.version_check.outputs.changed == 'true'
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag release
         if: steps.version_check.outputs.changed == 'true'


### PR DESCRIPTION
# Fix: remove redundant NODE_AUTH_TOKEN env from publish steps

## Summary

Removes redundant `NODE_AUTH_TOKEN` env declarations from the dry-run and publish steps in the publish workflow. The token is already configured at the job level via the `setup-node` action's `registry-url`, making per-step `env` blocks unnecessary.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- Removed `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the `Publish dry run` step
- Removed `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the `Publish to npm` step

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)