### PR TITLE
fix: remove leading dot from bin path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {
-    "rereadme": "./bin/rereadme.js"
+    "rereadme": "bin/rereadme.js"
   },
   "keywords": [
     "readme",
@@ -24,9 +24,17 @@
     "type": "git",
     "url": "git+https://github.com/cjlludwig/rereadme.git"
   },
-  "files": ["bin/", "lib/", "script.ts", "templates/", ".markdownlint.jsonc"],
-  "publishConfig": { "access": "public", "provenance": true },
-
+  "files": [
+    "bin/",
+    "lib/",
+    "script.ts",
+    "templates/",
+    ".markdownlint.jsonc"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "dev": "tsx ./script.ts",
     "build": "tsc",


### PR DESCRIPTION
# Fix: remove leading dot from bin path in package.json

## Summary

Fixes the `bin` entry in `package.json` by changing `./bin/rereadme.js` to `bin/rereadme.js`. The leading `./` caused npm to auto-correct and remove the entry during publish, which would have broken the CLI executable after installation.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- Changed `bin["rereadme"]` from `"./bin/rereadme.js"` to `"bin/rereadme.js"` in `package.json`
- Reformatted `files` array and `publishConfig` object for readability

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)