### PR TITLE
docs: replace git clone install instructions with npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Headless coding agents now interact with your repository repeatedly. Each sessio
 ## Quick Start
 
 ```shell
-git clone https://github.com/cjlludwig/rereadme.git
-cd rereadme && npm install && npm link
+npm install -g @cjlludwig/rereadme
 
 # Run in any repo
 cd /your/repo
@@ -61,24 +60,10 @@ rereadme
 #### Global Installation (Recommended)
 
 ```shell
-git clone https://github.com/cjlludwig/rereadme.git
-cd rereadme
-npm install
-npm link
+npm install -g @cjlludwig/rereadme
 
 # Verify installation
 rereadme --help
-```
-
-#### Local Installation
-
-```shell
-git clone https://github.com/cjlludwig/rereadme.git
-cd rereadme
-npm install
-
-# Check dependencies
-npm run check
 ```
 
 ## Usage

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,9 +11,12 @@ How to set up the repo locally, run the tool in development, execute tests and e
 ## Setup
 
 ```shell
-git clone https://github.com/connorludwig/rereadme.git
+git clone https://github.com/cjlludwig/rereadme.git
 cd rereadme
 npm install        # installs deps + configures the husky pre-commit hook automatically
+
+# Check dependencies
+npm run check
 ```
 
 To also set up the eval framework and dataset submodules:
@@ -111,7 +114,7 @@ git push
 3. Creates a GitHub Release with auto-generated notes from merged PR titles
 4. Commits a version bump to `.github/workflows/readme-ci.yml` so this repo uses the version it just released
 
-Verify the release at `https://www.npmjs.com/package/rereadme` and the GitHub Releases tab.
+Verify the release at `https://www.npmjs.com/package/@cjlludwig/rereadme` and the GitHub Releases tab.
 
 ## Standards
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Docs: replace git clone install instructions with npm install

## Summary

Updates installation instructions across README and development docs to use `npm install -g @cjlludwig/rereadme` now that the package is published to npm. Also fixes a stale `connorludwig` GitHub username in the development setup clone URL. Includes a version bump to `0.0.5`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `README.md`: replaced Quick Start and Global Installation git clone + npm link steps with `npm install -g @cjlludwig/rereadme`; renamed "Local Installation" to "Local Development"
- `docs/development.md`: fixed clone URL (`connorludwig` → `cjlludwig`); updated npm package URL to `@cjlludwig/rereadme`
- `package.json`: bumped version to `0.0.5`

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)