### PR TITLE
ci: skip pre-commit hook on publish auto-commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,6 @@ jobs:
           sed -i "s|cjlludwig/ReReadme@v[0-9]*\.[0-9]*\.[0-9]*|cjlludwig/ReReadme@v${VERSION}|g" \
             .github/workflows/readme-ci.yml
           git add .github/workflows/readme-ci.yml
-          git diff --cached --quiet || git commit -m "chore: update GHA ref to v${VERSION} [skip ci]"
+          git diff --cached --quiet || git commit --no-verify -m "chore: update GHA ref to v${VERSION} [skip ci]"
           git pull --rebase
           git push


### PR DESCRIPTION
# CI: skip pre-commit hook on publish auto-commit

## Summary

Adds `--no-verify` to the auto-generated git commit in the publish workflow that updates the `readme-ci.yml` version reference. The pre-commit hook fails in CI because `uv` is not installed in the publish runner, causing `make pre-commit` → `lint-py` to error out on a trivial single-line version string substitution.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `.github/workflows/publish.yml`: added `--no-verify` to the `git commit` in the "Update readme-ci.yml to new version" step

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)