### PR TITLE
docs: document model selection default and cost/quality tradeoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ rereadme --interactive
 # Specify output file
 rereadme --output README-new.md
 
-# Override the AI model
-rereadme --model gpt-4o
+# Override the AI model (default: gpt-5-nano, tuned for cost-efficiency)
+# Frontier models (e.g. gpt-4o, 5.2) produce richer output at higher cost
+rereadme --model gpt-5.2
 
 # Skip backup creation
 rereadme --no-backup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Adds a brief inline comment in the README CLI usage block noting that the default model is `gpt-5-nano` (tuned for cost-efficiency) and that frontier models produce richer output at higher cost. This gives users the context they need to make an informed choice when running `--model`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- Added two comment lines above `rereadme --model gpt-5.2` in the CLI usage block of `README.md` explaining the default model and the cost/quality tradeoff

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)