### PR TITLE
docs: use major version tag in example workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.3
+      - uses: cjlludwig/ReReadme@v0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 # ⚠️ README-suggestions.md written on drift

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.3
+      - uses: cjlludwig/ReReadme@v0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 # ⚠️ README-suggestions.md written on drift

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Switches the action ref in doc examples from a pinned patch version (`@v0.0.3`) to the major version tag (`@v0`). This prevents the examples from going stale — the publish workflow already pushes and force-updates the `v0` tag on every release, matching the convention used by actions like `actions/checkout@v4`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `README.md`: Updated example workflow ref from `cjlludwig/ReReadme@v0.0.3` to `cjlludwig/ReReadme@v0`
- `docs/workflows.md`: Same update

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)