### PR TITLE
fix: unset extra git auth header before pushing in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,7 @@ jobs:
           VERSION: ${{ steps.version_check.outputs.local }}
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/cjlludwig/ReReadme.git"
           BRANCH="chore/update-gha-ref-v${VERSION}"
           git checkout -b "$BRANCH"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Fix: unset extra git auth header before pushing in publish workflow

## Summary

Clears the `http.https://github.com/.extraheader` git config before setting the remote URL in the publish workflow. This prevents conflicts between GitHub Actions' injected auth header and the explicitly set token, which was causing push failures.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `.github/workflows/publish.yml`: Added `git config --unset-all http.https://github.com/.extraheader || true` before the remote URL override in the GHA ref update job
- `package.json`: Bumped version to `0.0.9`
- `package-lock.json`: Updated lock file to reflect version bump

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)