### PR TITLE
ci: add npm caching and improve --check output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: "npm"
 
       - run: npm ci
 
@@ -29,7 +30,6 @@ jobs:
         run: rereadme --check
         env:
           OPENAI_API_KEY: foo
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   smoke-test:
     runs-on: ubuntu-latest
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: "npm"
 
       - run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - run: npm ci
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: "24"
+        cache: "npm"
+        cache-dependency-path: "${{ github.action_path }}/package-lock.json"
     - run: npm ci
       shell: bash
       working-directory: ${{ github.action_path }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {

--- a/script.ts
+++ b/script.ts
@@ -444,6 +444,7 @@ async function main(): Promise<void> {
   if (args.check) {
     log.step('Checking dependencies')
     const depsOk = CI_MODE ? await checkCiDependencies() : await checkDependencies()
+    if (depsOk) log.info('All dependencies OK')
     process.exit(depsOk ? 0 : 1)
     return
   }


### PR DESCRIPTION
# ci: add npm caching and improve --check output

## Summary

Adds npm dependency caching to the CI workflow and composite action to speed up repeated runs. Also adds a confirmation log message when `--check` succeeds so users get explicit feedback instead of silence.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `ci.yml`: added `cache: "npm"` to `setup-node` in both `install-and-cli` and `smoke-test` jobs
- `action.yml`: added `cache: "npm"` and `cache-dependency-path` to `setup-node` so composite action installs are cached
- `script.ts`: log `All dependencies OK` when `--check` passes (always shown, not gated on `--verbose`)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)