### PR TITLE
fix: resolve npm cache path and bump to v0.0.11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,4 @@ A `Makefile` at the repo root drives all quality checks:
 - Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
 - Prefer `npm` script commands over `npx` for standardized scripts. Update if needed.
 - Prefer JSDocs for function level comments or descriptions. In-line should only be used if the logic isn't self explanatory or readable.
+- Any change to `action.yml`, `script.ts`, `lib/`, `bin/`, or `templates/` only takes effect for GHA consumers **after a new release is published**. When fixing a bug in these files, always proactively note: "This fix requires a version bump and release to take effect — bump `package.json` version to trigger the publish workflow."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Fix: resolve npm cache path and bump to v0.0.11

## Summary

Bumps the package version to 0.0.11 and updates CLAUDE.md to document that changes to action files require a new release to take effect for GHA consumers.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `package.json`: bump version to 0.0.11
- `package-lock.json`: updated to reflect version bump
- `CLAUDE.md`: add reminder that action file changes require a release

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)