### PR TITLE
fix: replace setup-node npm cache with actions/cache for composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0       # required to push tags
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,27 @@ branding:
 runs:
   using: composite
   steps:
-    - run: echo "ACTION_PATH=${{ github.action_path }}" >> "$GITHUB_ENV"
-      shell: bash
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: "24"
-        cache: "npm"
-        cache-dependency-path: "${{ env.ACTION_PATH }}/package-lock.json"
+    - uses: actions/github-script@v7
+      id: lock-hash
+      with:
+        script: |
+          const crypto = require('crypto')
+          const fs = require('fs')
+          const path = require('path')
+          const lockFile = path.join(process.env.GITHUB_ACTION_PATH, 'package-lock.json')
+          return crypto.createHash('sha256').update(fs.readFileSync(lockFile)).digest('hex')
+        result-encoding: string
+    - uses: actions/cache@v4
+      id: node-cache
+      with:
+        path: ${{ github.action_path }}/node_modules
+        key: ${{ runner.os }}-rereadme-node-${{ steps.lock-hash.outputs.result }}
+        restore-keys: ${{ runner.os }}-rereadme-node-
     - run: npm ci
+      if: steps.node-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
     - run: node ${{ github.action_path }}/bin/rereadme.js --ci --base-ref ${{ inputs.base-ref }} --head-ref HEAD ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}

--- a/docs/specs/publishing-ci.md
+++ b/docs/specs/publishing-ci.md
@@ -87,7 +87,7 @@ jobs:
           fetch-depth: 0       # required to push tags
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -178,7 +178,7 @@ Add a pack smoke test job that runs on every push/PR. Installs the CLI from the 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cjlludwig/rereadme",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {


### PR DESCRIPTION
# Fix: replace setup-node npm cache with actions/cache for composite action

## Summary

Fixes the persistent "Some specified paths were not resolved, unable to cache dependencies" error. Root cause: `hashFiles()` in `actions/setup-node` only resolves paths inside `GITHUB_WORKSPACE`, but composite action files live in `_actions/` — outside the workspace. Replaces the broken built-in cache with `actions/cache` using a SHA-256 hash of the lock file computed directly via `github-script`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Changes made

- `action.yml`: remove `GITHUB_ENV` workaround and `setup-node` cache config; add `github-script` step to hash `package-lock.json` via `GITHUB_ACTION_PATH`, add `actions/cache@v4` caching `node_modules`, skip `npm ci` on cache hit
- `package.json` / `package-lock.json`: bump to 0.0.12
- `.github/workflows/ci.yml`, `publish.yml`: update `setup-node` to `@v6`
- `docs/specs/publishing-ci.md`: update `setup-node` reference to `@v6`

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)