### PR TITLE
feat: refine README architecture workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,5 @@ DeepEval-based quality evaluation that runs rereadme against a dataset repo and 
 - Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
 - Prefer `npm` script commands over `npx` for standardized scripts. Update if needed.
 - Prefer JSDocs for function level comments or descriptions. In-line should only be used if the logic isn't self explanatory or readable.
+- When tuning agent prompts or model behavior, fix broad failure modes rather than literal eval misses. Prefer reusable guidance about discovery, evidence, structure, and tradeoffs; avoid embedding dataset-specific keywords, commands, or golden-output phrasing unless they represent a general product requirement.
 - Any change to `action.yml`, `script.ts`, `lib/`, `bin/`, or `templates/` only takes effect for GHA consumers after a new release is published. When fixing a bug in these files, always proactively note: "This fix requires a version bump and release to take effect — bump `package.json` version to trigger the publish workflow."

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -137,44 +137,85 @@ export function createAgents(model: string, readmeTemplate: string, agentsTempla
     name: 'ArchitectureDiagramAgent',
     model,
     outputType: ArchitectureDiagramOutputSchema,
-    instructions: `You are a repository architecture diagram researcher and README section writer. Produce a README-only architecture section that helps a developer understand the system at a macro level.
+    instructions: `You are a repository architecture diagram agent. Produce a concise README architecture section that helps a developer understand the system conceptually at a macro level.
 
-Use the provided read-only repository tools to gather evidence before deciding. Favor get_file_tree first, then read_files, search_code, and get_structure for targeted follow-up. Do not invent services, stores, callers, consumers, protocols, or deployment boundaries.
+## Research strategy
+Use tools in this order: get_file_tree → read_files → search_code → get_structure. Stop when you have enough to characterize topology. Do not invent nodes—except a single illustrative upstream caller (e.g., "Client") when the repo is clearly a service but contains no explicit caller code.
 
-Output contract:
-- Return includeDiagram, sectionMarkdown, rationale, and sourceFacts only.
-- sourceFacts must list concrete facts supported by repository evidence, including paths when possible.
-- rationale must be concise and explain why a diagram is or is not useful.
-- Include a diagram only when the project has non-obvious topology: multiple services, external dependencies, or a request/data flow not inferable from the file structure. Omit it for simple or single-concern repositories.
-- Always include a diagram for gateway, proxy, BFF, microservice front-end, API server with external storage, or service that has configured downstream service URLs, database connection settings, metrics endpoints, queues, caches, or other runtime integration points.
+## Decision rule
+Include a diagram when the repo has non-obvious topology: external dependencies, multiple services, configured downstream URLs/databases/queues/caches, or a request/data flow a reader can't infer from filenames alone. Skip it for single-concern libraries with no runtime integrations.
 
-When includeDiagram=true:
-- sectionMarkdown must be a complete \`## Architecture\` README section.
-- Keep sectionMarkdown short: the heading, at most one plain-English orientation sentence, and exactly one Mermaid fenced code block.
-- Do not include bullet lists, "Key components", "Data flow", file paths, function names, class names, or explanatory implementation inventories in sectionMarkdown.
-- The section must contain exactly one Mermaid fenced code block.
-- The Mermaid diagram must be a concise macro diagram with 3-8 visible nodes and at most 10 edges.
-- Include upstream callers, the repo/application boundary, and downstream services, stores, observability systems, or consumers when those relationships are supported by repository facts.
-- Use shape and color together: node shapes should communicate system type, while colors should communicate stack layer or boundary.
-- Use Mermaid's broadly supported flowchart node shapes for semantic clarity: rounded/stadium for callers or users, rectangles/subroutine boxes for app servers or repo-owned services, cylinders for databases/storage, distinct non-rectangular shapes for queues/caches/events/observability when present, and subgraphs for repo boundaries only when helpful.
-- Use tasteful color contrast to show stack layers and boundaries: callers, the repo/application boundary, downstream services, storage, and observability should have distinct but readable styles.
-- Do not use functions, classes, source files, controllers, services, DAOs, modules, packages, or other internal implementation layers as nodes.
-- Do not infer runtime dependencies from imports alone. Imports can guide research, but diagram facts must be supported by config, entrypoints, README/docs, API clients, environment variables, deployment files, or explicit integration code.
+Always include a diagram for: gateways, proxies, BFFs, API servers with external storage, microservices, or anything with configured downstream service URLs, DB connection strings, queue/cache references, or metrics endpoints.
 
-When includeDiagram=false:
-- sectionMarkdown should be an empty string, unless a minimal non-diagram \`## Architecture\` section is clearly useful from supported facts.
-- Do not include a Mermaid block.
+## Output format
+Return exactly these fields:
+- includeDiagram (bool)
+- sectionMarkdown (string)
+- rationale (one sentence)
+- sourceFacts (list of concrete repo-evidenced facts with paths)
 
-Mermaid requirements:
-- Use \`flowchart LR\`.
-- Every edge must be labeled with short labels using Mermaid pipe syntax, for example \`App -->|HTTP| API\`. Do not emit unlabeled edges.
-- Use short node labels; markdown labels are allowed where useful.
-- Prefer compatible bracket shape syntax over decorative icons, for example \`Client([Client])\`, \`App["API server"]\`, \`Worker[["Worker"]]\`, \`DB[("MongoDB")]\`, and \`Queue{{"Queue"}}\`.
-- An optional repo-boundary subgraph is allowed when it clarifies what is inside this repository.
-- Define all five classDef classes even if some are unused: caller, app, external, storage, and observability. Use distinct, theme-neutral, accessible colors. Prefer tasteful layer contrast over a mostly gray palette: blue callers, indigo application/repo boundary, amber downstream services, green storage, and purple observability.
-- Apply classes to relevant nodes.
-- Avoid icons, images, animations, decorative styling, and theme-specific assumptions.
-- Keep labels stable and readable in GitHub-flavored Markdown.`,
+## When includeDiagram = true
+sectionMarkdown must contain:
+1. A \`## Architecture\` heading
+2. At most one orientation sentence (plain English, conceptual)
+3. Exactly one Mermaid fenced code block
+
+No bullet lists, no component inventories, no file paths, no class/function names.
+
+## Diagram rules
+- \`flowchart LR\`
+- 3–8 nodes, ≤10 edges
+- Every edge labeled with pipe syntax: \`A -->|HTTP| B\`
+- Show: upstream callers, repo boundary (subgraph if helpful), downstream services/stores/observability
+- Nodes represent runtime actors only—no controllers, DAOs, modules, or internal layers
+- Base diagram facts on config, entrypoints, env vars, API clients, or deployment files—not imports alone
+
+## Node shapes
+| Type | Syntax |
+|---|---|
+| Caller / client | \`ID([Label])\` |
+| App server / service | \`ID[Label]\` |
+| Database / storage | \`ID[(Label)]\` |
+| Queue / worker | \`ID[[Label]]\` |
+| Observability | \`ID((Label))\` |
+
+## Diagram structure — order matters
+Emit blocks in this exact order or GitHub will drop styles:
+1. Node declarations (one per line, no edges)
+2. Edge definitions
+3. classDef blocks
+4. class assignments
+
+✓
+\`\`\`
+Gateway[Gateway]
+DB[(Database)]
+Gateway -->|HTTP| DB
+classDef storage fill:#86efac,color:#052e16
+class DB storage
+\`\`\`
+
+✗ \`Gateway[Gateway] -->|HTTP| DB[(Database)]\`
+
+## Edge style conventions
+- \`-->\`   synchronous / HTTP
+- \`-.->\`  async, event-driven, or fire-and-forget
+- \`==>\`   dominant request path (use at most once)
+- Extra dashes push peripheral nodes right: \`App ---->|metrics| Obs\`
+
+## Styling
+\`\`\`
+classDef caller       fill:#93c5fd,color:#1e3a5f
+classDef app          fill:#a5b4fc,color:#1e1b4b
+classDef external     fill:#fcd34d,color:#422006
+classDef storage      fill:#86efac,color:#052e16
+classDef observability fill:#d8b4fe,color:#3b0764
+\`\`\`
+
+Define all five classes even if unused. Apply to every node via \`class ID classname\`.
+
+## When includeDiagram = false
+sectionMarkdown = "" unless a minimal prose Architecture section adds clear value.`,
     tools: [getFileTree, readFiles, searchCode, getStructure],
     handoffDescription: 'Research and write an optional README Architecture section with a concise Mermaid diagram.',
   });
@@ -223,6 +264,7 @@ ${readmeTemplate}
 
 Additional rules:
 - Use clear, concise language for a developer audience.
+- Preserve the template's heading set. Do not add a heading that is absent from the template, even when repository facts would normally fit that topic; place those facts under the nearest relevant template section instead.
 - Do NOT repeat information across sections. Each fact belongs in exactly one section — place it where the template guidance says it goes.
 - READMEs are written in third-person neutral for descriptions and second-person imperative for instructions, addressed to a developer evaluating or adopting the project. Ensure output is aligned.
 - Your entire output must be ONLY the raw README markdown — no preamble, no closing commentary, no wrapping code fences`,

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -137,33 +137,30 @@ export async function runAgentWorkflow(
   attachToolLogger(readmeWriter, 'ReadmeWriter', stats);
   if (agentsDocWriter) attachToolLogger(agentsDocWriter, 'AgentsDocWriter', stats);
 
-  const totalSteps = agentsDocWriter ? 2 : 1;
-
-  // README pipeline: optional ArchitectureDiagramAgent + ReadmeWriter → deterministic composition → (AgentsDocWriter?)
+  // README pipeline: optional ArchitectureDiagramAgent → ReadmeWriter → deterministic composition → (AgentsDocWriter?)
   const { readme, agents } = await withTrace('ReReadme Agent Workflow', async () => {
-    log.verboseStep(`Step 1/${totalSteps}: README generation (model: ${model})`);
-    log.detail('ReadmeWriter started');
+    log.verboseStep(`Generating README (model: ${model})`);
+    let architecture: ArchitectureDiagramOutput | undefined;
     if (includeArchitecture) {
-      log.detail('ArchitectureDiagramAgent started (parallel)');
-    } else {
-      log.detail('ArchitectureDiagramAgent skipped (--no-architecture)');
-    }
-    const architecturePromise: Promise<ArchitectureDiagramOutput | undefined> = includeArchitecture
-      ? run(
+      log.detail('ArchitectureDiagramAgent started');
+      const result = await run(
         architectureDiagramAgent,
         'Analyze this repository and produce the README Architecture section decision.',
         { maxTurns: 25 },
-      ).then((result) => {
-        if (!result.finalOutput) {
-          throw new Error('ArchitectureDiagramAgent produced no output');
-        }
-        log.verboseStep(
-          `ArchitectureDiagramAgent done (includeDiagram=${result.finalOutput.includeDiagram}, facts=${result.finalOutput.sourceFacts.length})`,
-        );
-        return result.finalOutput;
-      })
-      : Promise.resolve(undefined);
-    const readmePromise = run(
+      );
+      if (!result.finalOutput) {
+        throw new Error('ArchitectureDiagramAgent produced no output');
+      }
+      architecture = result.finalOutput;
+      log.detail(
+        `ArchitectureDiagramAgent complete (diagram=${architecture.includeDiagram ? 'yes' : 'no'}, facts=${architecture.sourceFacts.length})`,
+      );
+    } else {
+      log.detail('ArchitectureDiagramAgent skipped (--no-architecture)');
+    }
+
+    log.detail('ReadmeWriter started');
+    const readmeResult = await run(
       readmeWriter,
       includeArchitecture
         ? `Generate a README.md for this repository.
@@ -171,29 +168,27 @@ export async function runAgentWorkflow(
 The Architecture section is composed by the workflow after README generation. Omit ## Architecture from your output; if you include it, it will be replaced deterministically.`
         : `Generate a README.md for this repository. Omit ## Architecture from your output because architecture generation is disabled.`,
       { maxTurns: 40 },
-    ).then((result) => {
-      if (!result.finalOutput || result.finalOutput.trim().length === 0) {
-        throw new Error('ReadmeWriter produced no output');
-      }
-      log.verboseStep(`ReadmeWriter done (${result.finalOutput.length} chars)`);
-      return stripFences(result.finalOutput);
-    });
+    );
+    if (!readmeResult.finalOutput || readmeResult.finalOutput.trim().length === 0) {
+      throw new Error('ReadmeWriter produced no output');
+    }
+    log.detail(`ReadmeWriter complete (${readmeResult.finalOutput.length} chars)`);
 
-    const [architecture, generatedReadme] = await Promise.all([architecturePromise, readmePromise]);
+    const generatedReadme = stripFences(readmeResult.finalOutput);
     const architectureSection = architecture?.sectionMarkdown.trim() ?? '';
     const readmeWithArchitecture = architectureSection
       ? composeReadmeWithArchitecture(generatedReadme, architectureSection)
       : removeMarkdownSection(generatedReadme, 'Architecture');
 
-    log.verboseStep(
+    log.detail(
       architectureSection
         ? 'Architecture section inserted'
         : 'Architecture section omitted',
     );
 
-    // Step 2 (optional): AgentsDocWriter generates AGENTS.md from the finalized README.
+    // Optional: AgentsDocWriter generates AGENTS.md from the finalized README.
     if (agentsDocWriter) {
-      log.verboseStep(`Step 2/${totalSteps}: AgentsDocWriter`);
+      log.verboseStep('Generating AGENTS.md');
       const initialAgentMdPrompt = `Generate an AGENTS.md for this repository using this finalized README as context:
 
 \`\`\`markdown
@@ -203,7 +198,7 @@ ${readmeWithArchitecture}
       if (!step2.finalOutput || step2.finalOutput.trim().length === 0) {
         throw new Error('AgentsDocWriter produced no output');
       }
-      log.verboseStep(`AgentsDocWriter done (${step2.finalOutput.length} chars)`);
+      log.detail(`AgentsDocWriter complete (${step2.finalOutput.length} chars)`);
       return { readme: readmeWithArchitecture, agents: step2.finalOutput };
     }
 

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -1,5 +1,11 @@
 import { run, withTrace, type Agent } from '@openai/agents';
-import { createAgents, createDiffAgents, type DiffAnalysis, type ReadmeSuggestion } from './agents.js';
+import {
+  createAgents,
+  createDiffAgents,
+  type ArchitectureDiagramOutput,
+  type DiffAnalysis,
+  type ReadmeSuggestion,
+} from './agents.js';
 import { composeReadmeWithArchitecture, removeMarkdownSection } from './markdown-sections.js';
 import { stripFences } from './readme-utils.js';
 import * as fs from 'node:fs';
@@ -116,47 +122,54 @@ export interface AgentWorkflowOptions {
   model: string;
   readmeTemplate: string;
   agentsTemplate?: string;
+  includeArchitecture?: boolean;
   verbose?: boolean;
 }
 
 export async function runAgentWorkflow(
   options: AgentWorkflowOptions,
 ): Promise<{ readme: string; agents?: string; stats: WorkflowStats }> {
-  const { model, readmeTemplate, agentsTemplate } = options;
+  const { model, readmeTemplate, agentsTemplate, includeArchitecture = true } = options;
 
   const { agentsDocWriter, architectureDiagramAgent, readmeWriter } = createAgents(model, readmeTemplate, agentsTemplate);
   const stats: WorkflowStats = { toolCallCount: 0, toolCallsByAgent: {}, toolCallsByTool: {} };
-  attachToolLogger(architectureDiagramAgent, 'ArchitectureDiagramAgent', stats);
+  if (includeArchitecture) attachToolLogger(architectureDiagramAgent, 'ArchitectureDiagramAgent', stats);
   attachToolLogger(readmeWriter, 'ReadmeWriter', stats);
   if (agentsDocWriter) attachToolLogger(agentsDocWriter, 'AgentsDocWriter', stats);
 
   const totalSteps = agentsDocWriter ? 2 : 1;
 
-  // README pipeline: ArchitectureDiagramAgent + ReadmeWriter in parallel → deterministic composition → (AgentsDocWriter?)
+  // README pipeline: optional ArchitectureDiagramAgent + ReadmeWriter → deterministic composition → (AgentsDocWriter?)
   const { readme, agents } = await withTrace('ReReadme Agent Workflow', async () => {
-    // Step 1: Generate README body and architecture section concurrently.
-    log.verboseStep(`Step 1/${totalSteps}: README generation (parallel, model: ${model})`);
-    log.verboseStep('ArchitectureDiagramAgent started');
-    const architecturePromise = run(
-      architectureDiagramAgent,
-      'Analyze this repository and produce the README Architecture section decision.',
-      { maxTurns: 25 },
-    ).then((result) => {
-      if (!result.finalOutput) {
-        throw new Error('ArchitectureDiagramAgent produced no output');
-      }
-      log.verboseStep(
-        `ArchitectureDiagramAgent done (includeDiagram=${result.finalOutput.includeDiagram}, facts=${result.finalOutput.sourceFacts.length})`,
-      );
-      return result.finalOutput;
-    });
-
-    log.verboseStep('ReadmeWriter started');
+    log.verboseStep(`Step 1/${totalSteps}: README generation (model: ${model})`);
+    log.detail('ReadmeWriter started');
+    if (includeArchitecture) {
+      log.detail('ArchitectureDiagramAgent started (parallel)');
+    } else {
+      log.detail('ArchitectureDiagramAgent skipped (--no-architecture)');
+    }
+    const architecturePromise: Promise<ArchitectureDiagramOutput | undefined> = includeArchitecture
+      ? run(
+        architectureDiagramAgent,
+        'Analyze this repository and produce the README Architecture section decision.',
+        { maxTurns: 25 },
+      ).then((result) => {
+        if (!result.finalOutput) {
+          throw new Error('ArchitectureDiagramAgent produced no output');
+        }
+        log.verboseStep(
+          `ArchitectureDiagramAgent done (includeDiagram=${result.finalOutput.includeDiagram}, facts=${result.finalOutput.sourceFacts.length})`,
+        );
+        return result.finalOutput;
+      })
+      : Promise.resolve(undefined);
     const readmePromise = run(
       readmeWriter,
-      `Generate a README.md for this repository.
+      includeArchitecture
+        ? `Generate a README.md for this repository.
 
-The Architecture section is composed by the workflow after README generation. You may omit ## Architecture. If you include it, it will be replaced deterministically.`,
+The Architecture section is composed by the workflow after README generation. Omit ## Architecture from your output; if you include it, it will be replaced deterministically.`
+        : `Generate a README.md for this repository. Omit ## Architecture from your output because architecture generation is disabled.`,
       { maxTurns: 40 },
     ).then((result) => {
       if (!result.finalOutput || result.finalOutput.trim().length === 0) {
@@ -167,12 +180,13 @@ The Architecture section is composed by the workflow after README generation. Yo
     });
 
     const [architecture, generatedReadme] = await Promise.all([architecturePromise, readmePromise]);
-    const readmeWithArchitecture = architecture.sectionMarkdown.trim()
-      ? composeReadmeWithArchitecture(generatedReadme, architecture.sectionMarkdown)
+    const architectureSection = architecture?.sectionMarkdown.trim() ?? '';
+    const readmeWithArchitecture = architectureSection
+      ? composeReadmeWithArchitecture(generatedReadme, architectureSection)
       : removeMarkdownSection(generatedReadme, 'Architecture');
 
     log.verboseStep(
-      architecture.sectionMarkdown.trim()
+      architectureSection
         ? 'Architecture section inserted'
         : 'Architecture section omitted',
     );

--- a/script.ts
+++ b/script.ts
@@ -57,6 +57,7 @@ const OPENAI_MODEL = typeof args.model === 'string' ? args.model : 'gpt-5-nano'
 const OUTPUT_FILE = typeof args.output === 'string' ? args.output : 'README.md'
 const GENERATE_AGENTS = Boolean(args.agents)
 const AGENTS_OUTPUT_FILE = typeof args['agents-output'] === 'string' ? args['agents-output'] : 'AGENTS.md'
+const INCLUDE_ARCHITECTURE = args['no-architecture'] !== true
 const SKIP_BACKUP = Boolean(args['no-backup'])
 const CI_MODE = Boolean(args.ci)
 const APPLY_MODE = Boolean(args.apply)
@@ -339,7 +340,10 @@ export async function runWorkflow(): Promise<void> {
     try {
       const result = await runAgentWorkflow({
         model: OPENAI_MODEL,
-        readmeTemplate, agentsTemplate, verbose: Boolean(args.verbose),
+        readmeTemplate,
+        agentsTemplate,
+        includeArchitecture: INCLUDE_ARCHITECTURE,
+        verbose: Boolean(args.verbose),
       })
       readmeContent = result.readme
       agentsContent = result.agents
@@ -428,6 +432,7 @@ ${pc.yellow('Options:')}
   --check                   Only check dependencies, don't run workflow
   --output FILE             Output to specified file instead of README.md
   --model MODEL             Override the default OpenAI model (default: gpt-5-nano)
+  --no-architecture         Skip ArchitectureDiagramAgent and omit Architecture output
   --no-backup               Skip creating backup files before overwriting
   --agents                  Also generate AGENTS.md (reuses Researcher output from Step 1)
   --agents-output FILE      Output AGENTS.md to specified file (default: AGENTS.md)
@@ -458,6 +463,7 @@ ${pc.yellow('Examples:')}
   rereadme --verbose                          # Show detailed output
   rereadme --check                            # Check dependencies only
   rereadme --model gpt-4o                     # Use a different OpenAI model
+  rereadme --no-architecture                  # Skip architecture diagram generation
   rereadme --output README-v2.md              # Output to custom filename
   rereadme --output README-v2.md     # Output to custom filename
   rereadme --template MY_TEMPLATE.md                # Use a custom README template


### PR DESCRIPTION
## Summary

Refines README generation so architecture output is controlled by the architecture agent rather than the README template. Adds an explicit opt-out flag for architecture generation, makes the workflow sequential to reduce TPM spikes, and tightens README prompt guidance around developer commands, validation workflows, and concrete observability details.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [x] Refactor (no functional changes)

## Changes made

- Updated `ReadmeWriter` guidance to avoid literal eval overfitting while improving discovery of task-runner commands, validation flows, deploy/build workflows, service constraints, and observability implementations.
- Changed the README workflow to run `ArchitectureDiagramAgent` sequentially before `ReadmeWriter`, insert architecture only when the architecture agent returns meaningful section markdown, and remove any writer-produced Architecture section otherwise.
- Added `--no-architecture` to skip architecture generation entirely and updated verbose output to read as a clean phase log.
- Added AGENTS.md guidance for future model/prompt tuning and bumped the package version to `0.0.14`.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Validated with:

- `make check`
- `make test`
- `npm run eval:front-end` spot check: generated front-end README/AGENTS artifacts for inspection, including restored Architecture output. The pytest fixture reported failure after CLI output due `Cleanup timeout, forcing exit`, so the generated artifacts were inspected directly under `evals/datasets/front-end` / `evals/results`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)