### PR TITLE
feat: ship compiled JS instead of running TypeScript via tsx at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Unit tests
         run: make test
 
+      - name: Build (compile dist/ before linking the CLI)
+        run: npm run build
+
       - run: npm link
 
       - name: Validate rereadme --help

--- a/.github/workflows/readme-ci.yml
+++ b/.github/workflows/readme-ci.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cjlludwig/ReReadme@v0.0.14
+      # TEMP(ship-compiled-js): dogfood the compiled-JS action via branch ref.
+      # REVERT to cjlludwig/ReReadme@v0.0.14 (or the released tag) before merging.
+      - uses: cjlludwig/ReReadme@ship-compiled-js
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           verbose: 'true'

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ runs:
       if: steps.node-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
+    - run: npm run build
+      shell: bash
+      working-directory: ${{ github.action_path }}
     - run: node ${{ github.action_path }}/bin/rereadme.js --ci --base-ref ${{ inputs.base-ref }} --head-ref HEAD ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
       shell: bash
       env:

--- a/bin/rereadme.js
+++ b/bin/rereadme.js
@@ -1,30 +1,6 @@
 #!/usr/bin/env node
 
-// CLI wrapper for rereadme TypeScript script
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { spawn } from 'child_process';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Path to the main TypeScript script
-const scriptPath = join(__dirname, '..', 'script.ts');
-
-// Use tsx to execute the TypeScript script with all command line arguments
-const tsxBin = join(__dirname, '..', 'node_modules', '.bin', 'tsx');
-const child = spawn(tsxBin, [scriptPath, ...process.argv.slice(2)], {
-  stdio: 'inherit',
-  cwd: process.cwd()
-});
-
-// Forward exit code
-child.on('exit', (code) => {
-  process.exit(code || 0);
-});
-
-// Handle errors
-child.on('error', (err) => {
-  console.error('Failed to start rereadme:', err.message);
-  process.exit(1);
-});
+// CLI wrapper: run the compiled rereadme entry point.
+// script.js self-executes (calls main()) and reads CLI args from process.argv,
+// so importing it runs the CLI with the same arguments.
+await import('../dist/script.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjlludwig/rereadme",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "CLI tool to refresh README automatically with up-to-date information based on code contents, documents, and external sources",
   "type": "module",
   "bin": {
@@ -26,10 +26,7 @@
   },
   "files": [
     "bin/",
-    "lib/",
-    "script.ts",
-    "templates/",
-    ".markdownlint.jsonc"
+    "dist/"
   ],
   "publishConfig": {
     "access": "public",
@@ -37,8 +34,8 @@
   },
   "scripts": {
     "dev": "tsx ./script.ts",
-    "build": "tsc",
-    "start": "node script.js",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc && node -e \"const fs=require('fs');fs.cpSync('templates','dist/templates',{recursive:true});fs.cpSync('.markdownlint.jsonc','dist/.markdownlint.jsonc')\"",
+    "start": "node dist/script.js",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest ./tests --coverage --coverageReporters=json-summary --cache --cacheDirectory=.cache/jest --silent",
     "test:full": "NODE_OPTIONS=--experimental-vm-modules jest ./tests --coverage --no-cache",
     "lint": "make lint-ts lint-md lint-py lint-pkg",
@@ -57,6 +54,7 @@
     "eval:report": "cd evals && NO_COLOR=1 uv run python evaluate.py",
     "eval:ci": "cd evals && uv run pytest test_ci_mode.py -v",
     "eval:all": "cd evals && uv run pytest -v",
+    "prepack": "npm run build",
     "prepare": "husky || true"
   },
   "dependencies": {
@@ -67,7 +65,6 @@
     "openai": "6.33.0",
     "picocolors": "1.1.1",
     "remark-parse": "11.0.0",
-    "tsx": "4.21.0",
     "unified": "11.0.5",
     "zod": "4.3.6",
     "zx": "8.8.5"
@@ -89,6 +86,7 @@
     "jest": "^30.2.0",
     "lint-staged": "^16.2.7",
     "publint": "^0.3.12",
+    "tsx": "4.21.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.56.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "node_modules",
     "dist",
     "*.spec.ts",
+    "jest.config.ts",
     "tests",
     "evals/datasets"
   ]


### PR DESCRIPTION
## Summary

Publishes compiled output from `dist/` instead of shipping raw `.ts` source and spawning `tsx` at runtime. Consumers (npm and the GitHub Action) no longer need a TypeScript runtime — `tsx` moves to a devDependency and only compiled JS ships.

## Type of change

- [x] Refactor / packaging change (no functional change to the agent workflow)
- [ ] Breaking change

> Not a code breaking change, but **requires a version bump + release** (bumped to `0.0.15`) to take effect for GHA/npm consumers.

## Changes made

- **`bin/rereadme.js`** — import the compiled `../dist/script.js` instead of spawning `node_modules/.bin/tsx` on `script.ts`
- **`package.json`** — `build` cleans `dist/`, runs `tsc`, and copies `templates/` + `.markdownlint.jsonc` into `dist/` (both read at runtime via `SCRIPT_DIR`); add `prepack` to build before publish; `files: [bin/, dist/]`; fix `start` → `node dist/script.js`; move `tsx` to `devDependencies`; bump version `0.0.15`
- **`action.yml`** — add `npm run build` step after `npm ci` (`npm ci` does not run `prepack`)
- **`tsconfig.json`** — exclude `jest.config.ts` from emit
- **`.github/workflows/readme-ci.yml`** — ⚠️ **TEMP** dogfood stub pointing at `@ship-compiled-js` (commit `f4de52c`) — **revert before merge**

> Note: `tsconfig` stayed on `ESNext`/`bundler`; switching to `NodeNext` broke typecheck via a known `openai` dual-resolution private-field mismatch. Compiled output is valid Node ESM regardless because all relative imports carry explicit `.js` extensions.

## Testing

- [x] Manual testing performed
- [x] Unit tests pass (88/88), `make check` clean, `publint` clean

Validated locally before push:
- **Clean-room tarball install** (`npm install <tarball>` + global `-g`): CLI runs from installed location; **`tsx` absent** from consumer tree; only `dist/` ships, **no `.ts` source**; `--check` → All dependencies OK
- **Full end-to-end run** via compiled bin (~175s): generates a valid README, markdownlint step passes (this caught a real `.markdownlint.jsonc` lookup regression, now fixed)
- **Publish gates** (mirrors `publish.yml`): `publint` clean, pack size **28 kB** (< 500 kB), `npm publish --dry-run` clean
- **GitHub Action path** — validated by this PR's own README-CI run via the temp branch-ref stub

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (n/a — no doc-facing changes)